### PR TITLE
Add species identifier next to pet name on adoptable pets view

### DIFF
--- a/app/views/organizations/adoptable_pets/index.html.erb
+++ b/app/views/organizations/adoptable_pets/index.html.erb
@@ -66,11 +66,16 @@
             <%= c.with_body do %>
               <ul class="list-group list-group-flush">
                 <li class="list-group-item d-flex justify-content-between align-items-center flex-wrap">
-                  <%= link_to adoptable_pet_path(pet), class: 'text-decoration-none' do %>
-                    <h3 class="card-title text-secondary mb-0">
-                      <%= pet.name %>
-                    </h3>
-                  <% end %>
+                  <div class="d-flex align-items-center justify-content-start gap-3">
+                    <%= link_to adoptable_pet_path(pet), class: 'text-decoration-none' do %>
+                      <h3 class="card-title text-secondary mb-0">
+                        <%= pet.name %>
+                      </h3>
+                    <% end %>
+                    <span class="badge bg-secondary-soft text-secondary">
+                      <%= pet.species %>
+                    </span>
+                  </div>
                   <% if allowed_to?(:create?, Like, context: {pet: pet}) %>
                     <div class='text-end' id="like_button_pet_<%= pet.id %>">
                       <%= render LikeButtonComponent.new(pet: pet, like: @likes_by_id[pet.id]) %>

--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -63,8 +63,11 @@
         <%= render CardComponent.new(image_options: {default: ""}) do |c| %>
           <%= c.with_header do %>
             <div class="d-flex justify-content-between align-items-center">
-              <div>
+              <div class="d-flex justify-content-between align-items-center gap-3">
                 <h4 class="mb-0"><%= "#{t('general.about')} #{@pet.name}" %></h4>
+                <span class="badge bg-secondary-soft text-secondary">
+                  <%= @pet.species %>
+                </span>
               </div>
 
               <% if allowed_to?(:create?, Like, context: {pet: @pet}) %>


### PR DESCRIPTION
# 🔗 Issue
#1061 

# ✍️ Description
Added a species identifier next to the pet name on the /adoptable_pets page.

# 📷 Screenshots/Demos
Not logged in:
![Screenshot from 2024-10-19 13-17-34](https://github.com/user-attachments/assets/f1c84e07-5aad-46e1-9961-729e77ec569a)
Logged in as adopter fosterer:
![Screenshot from 2024-10-19 13-17-25](https://github.com/user-attachments/assets/8bbdf40e-025f-4bb6-9939-36b323ba56cb)
Logged in as staff:
![Screenshot from 2024-10-19 13-17-05](https://github.com/user-attachments/assets/c55094eb-b355-4c17-b688-e3f47f3e00f8)
Mobile:
![Screenshot from 2024-10-19 12-47-25](https://github.com/user-attachments/assets/07910ae5-2816-4012-8a64-31ab70bf18b5)
