### PR TITLE
Filter breed options on species selection

### DIFF
--- a/app/javascript/controllers/filter_breed_controller.js
+++ b/app/javascript/controllers/filter_breed_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["breeds", "species"];
+
+  // Necessary if page is refreshed with a species selected
+  connect() {
+    this.update();
+  }
+
+  update() {
+    const speciesNode = this.speciesTarget.selectedOptions[0]
+    const speciesValue = speciesNode.value
+    const speciesText = speciesNode.innerText
+
+    // If selected value is an empty string, "All" has been selected so display all breeds
+    speciesValue == "" ? this._displayAllBreeds() : this._filterBreedsBySpecies(speciesText)
+  }
+
+  _filterBreedsBySpecies(species) {
+    for (const child of this.breedsTarget.children) {
+      // Always display the breed option of "All"
+      if (child.nodeName.toLowerCase() == "option") {
+        continue;
+      }
+
+      // Hide breeds from other species
+      if (child.label == species) {
+        child.style.display = "block";
+      } else {
+        child.style.display = "none";
+      }
+    }
+  }
+
+  _displayAllBreeds() {
+    for (const child of this.breedsTarget.children) {
+      child.style.display = "block";
+    }
+  }
+}

--- a/app/views/organizations/adoptable_pets/index.html.erb
+++ b/app/views/organizations/adoptable_pets/index.html.erb
@@ -16,7 +16,7 @@
       <div class="col m-2">
       <!--filter section-->
         <%= search_form_for @q, url:adoptable_pets_path do |f| %>
-          <div class='d-flex justify-content-center align-items-center flex-wrap mb-3 p-4 gap-3 rounded-5 bg-white' >
+          <div class='d-flex justify-content-center align-items-center flex-wrap mb-3 p-4 gap-3 rounded-5 bg-white' data-controller="filter-breed">
             <div class="d-flex gap-3 flex-wrap align-items-end">
               <div class="form-group">
                 <%= f.label :name_i_cont, "Name" %>
@@ -28,11 +28,11 @@
               </div>
               <div class="form-group">
                 <%= f.label :species_eq, "Species" %>
-                <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select" %>
-              </div>              
+                <%= f.select :species_eq, Pet.species, {include_blank: 'All'}, class: "form-select", "data-filter-breed-target": "species", "data-action": "input->filter-breed#update" %>
+              </div>
               <div class="form-group">
                 <%= f.label :breed_eq, "Breed" %>
-                <%= f.select :breed_eq, get_animals, {include_blank: 'All'}, class: "form-select" %>
+                <%= f.select :breed_eq, get_animals, {include_blank: 'All'}, class: "form-select", "data-filter-breed-target": "breeds" %>
               </div>
               <div class="form-group">
                 <%= f.label :ransack_birth_date, "Age" %>

--- a/test/system/adoptable_pets_test.rb
+++ b/test/system/adoptable_pets_test.rb
@@ -1,0 +1,33 @@
+require "application_system_test_case"
+
+class AdoptablePetsTest < ApplicationSystemTestCase
+  setup do
+    create(:pet, species: "Dog", breed: "Labrador")
+    create(:pet, species: "Dog", breed: "Pitbull")
+    create(:pet, species: "Cat", breed: "Sphinx")
+    create(:pet, species: "Cat", breed: "Siamese")
+  end
+
+  # TODO:Selecting the species should trigger an `input` event, but it doesn't because of a bug in Cuprite.
+  # Remove the `page.evaluate_script` lines below once the bug has been fixed.
+  # See: https://github.com/rubycdp/cuprite/issues/223
+  test "selecting species filters breed dropdown options" do
+    visit adoptable_pets_path
+    assert_select("Breed", selected: ["All"], options: ["All", "Labrador", "Pitbull", "Siamese", "Sphinx"])
+
+    select("Dog", from: "Species")
+    page.evaluate_script("Stimulus.controllers[0].update()")
+
+    assert_select("Breed", options: ["All", "Labrador", "Pitbull"])
+
+    select("Cat", from: "Species")
+    page.evaluate_script("Stimulus.controllers[0].update()")
+
+    assert_select("Breed", options: ["All", "Sphinx", "Siamese"])
+
+    select("All", from: "Species")
+    page.evaluate_script("Stimulus.controllers[0].update()")
+
+    assert_select("Breed", selected: ["All"], options: ["All", "Labrador", "Pitbull", "Siamese", "Sphinx"])
+  end
+end


### PR DESCRIPTION
# 🔗 Issue
No issue :eyes: 

# ✍️ Description
A small UX improvement I thought of.

When you select a species ("Dog" for example), we can reduce the number of options for the breed drop-down and only show dog breeds.

# 📷 Screenshots/Demos
[screencast3.webm](https://github.com/user-attachments/assets/2efb724c-50d4-4328-b7c0-5916b5833aa3)