### PR TITLE
Change org/home create account button to sing up and style change

### DIFF
--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -171,8 +171,8 @@
         <div class="col-8 offset-2 border p-5 shadow-sm
                     rounded bg-white">
           <h3 class='mb-4'>Become an adopter now!</h3>
-          <%= link_to 'Create Account', new_user_registration_path ,
-                      class: 'custom-btn-pink' %>
+          <%= link_to 'Sign Up', new_user_registration_path ,
+                      class: 'btn btn-primary' %>
         </div>
       </div>
     </div>

--- a/test/system/home_page_test.rb
+++ b/test/system/home_page_test.rb
@@ -7,11 +7,16 @@ class HomePageTest < ApplicationSystemTestCase
     set_organization(@organization)
   end
 
-  test "renders custom hero and about text from CustomPage or default text" do
+  test "renders custom hero and about text from CustomPage or default text, checks cta button link" do
     CustomPage.create(hero: "Super Pets for a good paws", about: "All about us")
 
     visit home_index_path
     assert_text "Super Pets for a good paws"
     assert_text "All about us"
+    assert_selector "#cta"
+
+    within "#cta" do
+      assert_selector "a", text: "Sign Up"
+    end
   end
 end


### PR DESCRIPTION
# 🔗 Issue
closes issue #1071 

# ✍️ Description
#1071 issue fixed. Changed the organization home page link from "create account" to a button styling as "Sign Up".
Also added a small test in test/system/home_page_test.rb to check if the button is there with the correct text.


# 📷 Screenshots/Demos

<img width="654" alt="Screenshot 2024-10-21 at 12 28 51 PM" src="https://github.com/user-attachments/assets/94cc4a26-3db4-4b65-a893-00b782d0346a">
