### PR TITLE
1098 - Fix  settings link under Admin section

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -26,6 +26,8 @@ class ApplicationPolicy < ActionPolicy::Base
   # Define shared methods useful for most policies.
 
   def organization
+    return record if record.is_a?(Organization)
+
     @organization || record.organization
   end
 

--- a/app/policies/organizations/organization_policy.rb
+++ b/app/policies/organizations/organization_policy.rb
@@ -5,11 +5,5 @@ module Organizations
     def manage?
       permission?(:manage_organization)
     end
-
-    private
-
-    def organization
-      record
-    end
   end
 end


### PR DESCRIPTION
# 🔗 Issue
#1098 

# ✍️ Description
Log in as staff and go to the dashboard. In the navbar there should be a Settings link under Admin section. This is not visible, but you can access it by going to /staff/organization/edit.

In `OrganizationPolicy`, the `verify_active_staff!` pre-check was failing because the organization method was returning nil. This happened because the organization method in `ApplicationPolicy` was set to always call `record.organization`, which only works when `record` is something associated with an organization (like a CustomPage, User, or another related class). However, if `record` itself is an `Organization`, `record.organization` is not valid. To fix this, I updated the organization method to return record directly when record is an Organization, ensuring the method works correctly for both cases.

# 📷 Screenshots/Demos
<img width="216" alt="Screenshot 2024-11-05 at 10 29 08" src="https://github.com/user-attachments/assets/e4e937e3-fad4-4db9-9bb2-76bcdfa7ada3">

