### PR TITLE
Update routes for footer links to legal pages

### DIFF
--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -102,9 +102,9 @@
       <!-- Links -->
       <div class="col-12 col-md-7 col-lg-8 d-md-flex justify-content-end">
         <nav class="nav nav-footer">
-          <a class="nav-link ps-0" href="#"><%= t('.policy') %></a>
-          <a class="nav-link px-2 px-md-3" href="#"><%= t('.cookie') %></a>
-          <a class="nav-link" href="#"><%= t('.terms') %></a>
+          <%= link_to t('.policy'), privacy_policy_path, target: '_blank', class: 'nav-link' %>
+          <%= link_to t('.cookie'), cookie_policy_path, target: '_blank',  class: 'nav-link' %>
+          <%= link_to t('.terms'), terms_and_conditions_path, target: '_blank',  class: "nav-link"%>
         </nav>
       </div>
     </div>


### PR DESCRIPTION
# [🔗][Footer: update links to the legal stuff](https://github.com/rubyforgood/homeward-tails/issues/1100#top)](https://github.com/rubyforgood/homeward-tails/issues/1100)


# ✍️ Description
Updated footer links to point to the correct routes for legal pages, based on the working signup links. Also addressed inconsistency in link text, changing 'Terms of Use' to 'Terms and Conditions' to match the signup page.

# 📷 Screenshots/Demos
![image](https://github.com/user-attachments/assets/19a6c61a-0d6c-440d-9c48-457ac10843ae)

