### PR TITLE
1062 empty state message for no match

### DIFF
--- a/app/controllers/organizations/adoptable_pets_controller.rb
+++ b/app/controllers/organizations/adoptable_pets_controller.rb
@@ -27,6 +27,11 @@ module Organizations
       )
 
       @pets = paginated_adoptable_pets
+
+      if @pets.empty?
+        flash[:alert] = "We don't have any pets matching your search criteria."
+        redirect_to adoptable_pets_path(species: @species)
+      end
     end
 
     def show

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,17 +2,17 @@
 #
 # Table name: organizations
 #
-#  id                          :bigint           not null, primary key
-#  donation_url                :text
-#  email                       :string           not null
-# external_form_url :text
-#  facebook_url                :text
-#  instagram_url               :text
-#  name                        :string           not null
-#  phone_number                :string
-#  slug                        :string           not null
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                :bigint           not null, primary key
+#  donation_url      :text
+#  email             :string           not null
+#  external_form_url :text
+#  facebook_url      :text
+#  instagram_url     :text
+#  name              :string           not null
+#  phone_number      :string
+#  slug              :string           not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
 #
 # Indexes
 #

--- a/app/views/organizations/adoptable_pets/index.html.erb
+++ b/app/views/organizations/adoptable_pets/index.html.erb
@@ -52,50 +52,62 @@
       </div>
     </div>
 
-    <div class="d-flex justify-content-center align-items-center mt-2">
-      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
-    </div>
-
-    <div class="row">
-      <% @pets.each do |pet| %>
-        <div class="col-lg-4 col-md-6 p-0">
-          <%= render CardComponent.new(
-            card_options: {class: "card card-hover m-4"},
-            image_options: {src: pet.images.first, url: adoptable_pet_path(pet)}
-          ) do |c| %>
-            <%= c.with_badge do %>
-              <%= render BadgeComponent.new("Adoption Pending", class: "badge bg-info", when: pet.has_adoption_pending?) %>
-              <%= render BadgeComponent.new("Adopted", class: "badge bg-warning", when: pet.is_adopted?) %>
-            <% end %>
-            <%= c.with_body do %>
-              <ul class="list-group list-group-flush">
-                <li class="list-group-item d-flex justify-content-between align-items-center flex-wrap">
-                  <div class="d-flex align-items-center justify-content-start gap-3">
-                    <%= link_to adoptable_pet_path(pet), class: 'text-decoration-none' do %>
-                      <h3 class="card-title text-secondary mb-0">
-                        <%= pet.name %>
-                      </h3>
-                    <% end %>
-                    <span class="badge bg-secondary-soft text-secondary">
-                      <%= pet.species %>
-                    </span>
-                  </div>
-                  <% if allowed_to?(:create?, Like, context: {pet: pet}) %>
-                    <div class='text-end' id="like_button_pet_<%= pet.id %>">
-                      <%= render LikeButtonComponent.new(pet: pet, like: @likes_by_id[pet.id]) %>
-                    </div>
-                  <% end %>
-                </li>
-                <% li_classes = %w[list-group-item text-secondary] %>
-                <%= tag.li("Age: #{time_ago_in_words(pet.birth_date).titleize}", class: li_classes) %>
-                <%= tag.li("Breed: #{pet.breed}", class: li_classes) %>
-                <%= tag.li("Sex: #{pet.sex}", class: li_classes) %>
-                <%= tag.li("Weight range: #{[pet.weight_from, pet.weight_to].join("-")} #{pet.weight_unit}", class: li_classes) %>
-              </ul>
-            <% end %>
-          <% end %>
+    <% if @pets.empty? %>
+      <div class="row mt-4">
+        <div class="col-12">
+          <div class="card text-center mx-auto" style="max-width: 400px;">
+            <div class="card-body">
+              <p class="text-danger">We don't have any pets matching your search criteria.</p>
+            </div>
+          </div>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% else %>
+      <div class="d-flex justify-content-center align-items-center mt-2">
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+      </div>
+
+      <div class="row">
+        <% @pets.each do |pet| %>
+          <div class="col-lg-4 col-md-6 p-0">
+            <%= render CardComponent.new(
+              card_options: {class: "card card-hover m-4"},
+              image_options: {src: pet.images.first, url: adoptable_pet_path(pet)}
+            ) do |c| %>
+              <%= c.with_badge do %>
+                <%= render BadgeComponent.new("Adoption Pending", class: "badge bg-info", when: pet.has_adoption_pending?) %>
+                <%= render BadgeComponent.new("Adopted", class: "badge bg-warning", when: pet.is_adopted?) %>
+              <% end %>
+              <%= c.with_body do %>
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item d-flex justify-content-between align-items-center flex-wrap">
+                    <div class="d-flex align-items-center justify-content-start gap-3">
+                      <%= link_to adoptable_pet_path(pet), class: 'text-decoration-none' do %>
+                        <h3 class="card-title text-secondary mb-0">
+                          <%= pet.name %>
+                        </h3>
+                      <% end %>
+                      <span class="badge bg-secondary-soft text-secondary">
+                        <%= pet.species %>
+                      </span>
+                    </div>
+                    <% if allowed_to?(:create?, Like, context: {pet: pet}) %>
+                      <div class='text-end' id="like_button_pet_<%= pet.id %>">
+                        <%= render LikeButtonComponent.new(pet: pet, like: @likes_by_id[pet.id]) %>
+                      </div>
+                    <% end %>
+                  </li>
+                  <% li_classes = %w[list-group-item text-secondary] %>
+                  <%= tag.li("Age: #{time_ago_in_words(pet.birth_date).titleize}", class: li_classes) %>
+                  <%= tag.li("Breed: #{pet.breed}", class: li_classes) %>
+                  <%= tag.li("Sex: #{pet.sex}", class: li_classes) %>
+                  <%= tag.li("Weight range: #{[pet.weight_from, pet.weight_to].join("-")} #{pet.weight_unit}", class: li_classes) %>
+                </ul>
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
   </div> <!--container-->
 </section>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,6 +57,15 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_08_095758) do
     t.index ["pet_id"], name: "index_adopter_applications_on_pet_id"
   end
 
+  create_table "adopter_foster_accounts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.bigint "organization_id", null: false
+    t.index ["organization_id"], name: "index_adopter_foster_accounts_on_organization_id"
+    t.index ["user_id"], name: "index_adopter_foster_accounts_on_user_id"
+  end
+
   create_table "custom_pages", force: :cascade do |t|
     t.bigint "organization_id", null: false
     t.string "hero"
@@ -240,6 +249,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_08_095758) do
     t.datetime "updated_at", null: false
     t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
     t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
+  end
+
+  create_table "staff_accounts", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "organization_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "deactivated_at"
+    t.index ["organization_id"], name: "index_staff_accounts_on_organization_id"
+    t.index ["user_id"], name: "index_staff_accounts_on_user_id"
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/test/controllers/organizations/adoptable_pets_controller_test.rb
+++ b/test/controllers/organizations/adoptable_pets_controller_test.rb
@@ -6,7 +6,7 @@ module Organizations
     include ActionPolicy::TestHelper
 
     setup do
-      @pet = create(:pet, species: "Dog")
+      @pet = create(:pet, species: "Dog", name: "Buddy")
     end
 
     context "#index" do
@@ -36,6 +36,13 @@ module Organizations
         assert_select(".card li:nth-of-type(3)", text: "Breed: #{@pet.breed}")
         assert_select(".card li:nth-of-type(4)", text: "Sex: #{@pet.sex}")
         assert_select(".card li:nth-of-type(5)", text: "Weight range: #{@pet.weight_from}-#{@pet.weight_to} #{@pet.weight_unit}")
+      end
+
+      should "render message if no pets meet search criteria" do
+        get adoptable_pets_url(species: "dog", q: {name_cont: "Guy"})
+
+        assert_redirected_to adoptable_pets_path(species: "dog")
+        assert_equal "We don't have any pets matching your search criteria.", flash[:alert]
       end
     end
 


### PR DESCRIPTION
# 🔗 Issue #1062 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

This PR implements adding an empty state message when a user searches for a pet that yields no results. This will help with user confusion by giving a descriptive flash alert - " We don't have any pets matching your search criteria. "

The user will then be redirected to the species they previously searched for. Another option is only to flash a message without the redirect. 

Is there a preference? Not sure if the redirect is needed but it seemed like the right thing to do!

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
https://jam.dev/c/353f28c2-9742-4b8a-bdba-6603774203a3
