### PR TITLE
 add: empty state message to adoptable pets view

### DIFF
--- a/app/views/organizations/adoptable_pets/index.html.erb
+++ b/app/views/organizations/adoptable_pets/index.html.erb
@@ -51,10 +51,22 @@
         <% end %>
       </div>
     </div>
-
-    <div class="d-flex justify-content-center align-items-center mt-2">
-      <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
-    </div>
+      
+      <% if @pets.empty? %>
+      <div class="row mt-4">
+        <div class="col-12">
+          <div class="card text-center mx-auto" style="max-width: 400px;">
+            <div class="card-body">
+              <p class="text-danger">We don't have any pets matching your search criteria.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% else %>
+      <div class="d-flex justify-content-center align-items-center mt-2">
+        <%== pagy_bootstrap_nav(@pagy) if @pagy.pages > 1 %>
+      </div>
+    <% end %>
 
     <div class="row">
       <% @pets.each do |pet| %>

--- a/app/views/organizations/adoptable_pets/index.html.erb
+++ b/app/views/organizations/adoptable_pets/index.html.erb
@@ -57,7 +57,7 @@
         <div class="col-12">
           <div class="card text-center mx-auto" style="max-width: 400px;">
             <div class="card-body">
-              <p class="text-danger">We don't have any pets matching your search criteria.</p>
+              <p class="class-text">We don't have any pets matching your search criteria.</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION

# 🔗 Issue #1062 
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

This PR implements adding an empty state message to the adoptable pet view when a user searches for a pet and does not yield any results. This will help with user confusion by giving a descriptive message: " We don't have any pets matching your search criteria. "

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
![Screenshot 2024-11-19 at 7 51 51 PM](https://github.com/user-attachments/assets/e527b74b-c5b1-4f5c-8891-364a2de55b9f)
