### PR TITLE
1187 Update migrations for backfilling

### DIFF
--- a/db/migrate/20241122053814_add_locatable_to_locations.rb
+++ b/db/migrate/20241122053814_add_locatable_to_locations.rb
@@ -1,9 +1,7 @@
 class AddLocatableToLocations < ActiveRecord::Migration[7.2]
-  def change
-    safety_assured do
-      remove_reference :locations, :organization, foreign_key: true
+  disable_ddl_transaction!
 
-      add_reference :locations, :locatable, polymorphic: true, null: false, index: true
-    end
+  def change
+    add_reference :locations, :locatable, polymorphic: true, null: true, index: {algorithm: :concurrently}
   end
 end

--- a/db/migrate/20241127052013_backfill_locatable_for_locations.rb
+++ b/db/migrate/20241127052013_backfill_locatable_for_locations.rb
@@ -1,0 +1,22 @@
+class BackfillLocatableForLocations < ActiveRecord::Migration[7.2]
+  def up
+    # All locatables were previously organizations
+    Location.find_each do |location|
+      location.update!(
+        locatable_type: "Organization",
+        locatable_id: location.organization_id
+      )
+    end
+
+    safety_assured do
+      change_column_null :locations, :locatable_id, false
+      change_column_null :locations, :locatable_type, false
+    end
+  end
+
+  def down
+    Location.find_each do |location|
+      location.update!(organization_id: location.locatable_id)
+    end
+  end
+end

--- a/db/migrate/20241127052542_remove_organization_from_locations.rb
+++ b/db/migrate/20241127052542_remove_organization_from_locations.rb
@@ -1,0 +1,7 @@
+class RemoveOrganizationFromLocations < ActiveRecord::Migration[7.2]
+  def change
+    safety_assured do
+      remove_reference :locations, :organization, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_22_053814) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_27_052542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
# 🔗 Issue
#1187 

# ✍️ Description
Fixes migration by breaking it up into steps and including back filling.

Note this ignores some of the strong migrations practices, but this is literally affecting one Location record, so it's unnecessary to worry about write times.