### PR TITLE
#1189 Add www to config.hosts and proxy

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -18,7 +18,7 @@ servers:
 # in Cloudflare's SSL/TLS setting to "Full" to enable end-to-end encryption.
 proxy:
   ssl: true
-  host: homewardtails.org
+  host: "homewardtails.org,www.homewardtails.org"
   app_port: 3000
 
 # Credentials for your image host.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,4 +101,6 @@ Rails.application.configure do
     default: {baja: "bajapetrescue@gmail.com"},
     contact: {baja: "bajapetrescue+contact@gmail.com"}
   }
+
+  config.hosts = ["homewardtails.org", "www.homewardtails.org"]
 end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
Resolves #1189 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This permits the hosts "www.homewardtails.org" and "homewardtails.org" in production. The kamal proxy was also updated to include the www subdomain.

One thing I considered was added a route to redirect all www traffic to the naked domain( [reference](https://masilotti.com/rails-redirect-www/) ). However, I ran into a bunch of failing test and I'm not familiar with this enough to resolve it without guessing. This is probably a lower priority but worth mentioning.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
