### PR TITLE
Fix deployment failure - Hosts

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,6 +101,4 @@ Rails.application.configure do
     default: {baja: "bajapetrescue@gmail.com"},
     contact: {baja: "bajapetrescue+contact@gmail.com"}
   }
-
-  config.hosts = ["homewardtails.org", "www.homewardtails.org"]
 end


### PR DESCRIPTION


# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Adding the hosts names to config.hosts causes the deployment to fail.
```
   INFO [0fb5bacc] Running docker exec kamal-proxy kamal-proxy deploy homewardtails-web --target="d9ef7a514e43:3000" --host="homewardtails.org" --host="www.homewardtails.org" --tls --deploy-timeout="30s" --drain-timeout="30s" --buffer-requests --buffer-responses --log-request-header="Cache-Control" --log-request-header="Last-Modified" --log-request-header="User-Agent" on homewardtails.org
 ERROR Failed to boot web on homewardtails.org
```

The www subdomain does works by defining the host name in deploy.yml.  This was in the previous commit. I did a kamal deploy from my machine without the config.hosts set and www.homewardtails.org worked in production.

Config.hosts is to help prevent DNS rebinding attacks. I'm not sure how to make that work. I did attempt to push the domain names into the config.hosts array instead of using `=` in case something was already in the array that I may have overwritten but that did not fix the issue.

```
#does not resolve issue
config.hosts << "homewardtails.org"
config.hosts << "www.homewardtails.org"
```

**Do note that until this temp fix is merge into main, all deployments will fail**


