### PR TITLE
Mailer fix

### DIFF
--- a/app/mailers/sign_up_mailer.rb
+++ b/app/mailers/sign_up_mailer.rb
@@ -3,6 +3,6 @@ class SignUpMailer < ApplicationMailer
     @organization = current_tenant
     @user = params[:user]
 
-    mail(to: @user.email, subject: "Welcome to #{@organization.name}")
+    mail(to: @user.email, subject: "No Reply: Welcome to #{@organization.name}")
   end
 end

--- a/app/views/adoption_mailer/new_adoption.html.erb
+++ b/app/views/adoption_mailer/new_adoption.html.erb
@@ -6,7 +6,7 @@
   <body>
     <h1>Congrats on <%= @pet.name %>'s adoption!</h1>
 
-    <p>To view <%= @pet.name %>'s tasks and downloadable files, please go to your <%= link_to "Adopted Pets", adopter_fosterer_adopted_pets_url(script_name: "#{@organization.slug}"), target: "_blank" %> page.</p>
+    <p>To view <%= @pet.name %>'s tasks and downloadable files, please go to your <%= link_to "Adopted Pets", adopter_fosterer_adopted_pets_url(script_name: "/#{@organization.slug}"), target: "_blank" %> page.</p>
 
     <p>Have a great day!</p>
 

--- a/app/views/foster_mailer/new_foster.html.erb
+++ b/app/views/foster_mailer/new_foster.html.erb
@@ -11,7 +11,7 @@
     <h4>Foster Start Date: <%= @foster.start_date.strftime("%Y-%m-%d") %></h4>
     <h4>Foster End Date: <%= @foster.end_date.strftime("%Y-%m-%d") %></h4>
 
-    <p>To view <%= @pet.name %>'s tasks and downloadable files, please go to your <%= link_to "Fostered Pets", adopter_fosterer_fostered_pets_url(script_name: "#{@organization.slug}"), target: "_blank" %> page.</p>
+    <p>To view <%= @pet.name %>'s tasks and downloadable files, please go to your <%= link_to "Fostered Pets", adopter_fosterer_fostered_pets_url(script_name: "/#{@organization.slug}"), target: "_blank" %> page.</p>
 
     <strong>Please do not reply directly to this email. You must contact <%= @organization.name %> directly at <a href="mailto:<%= @organization.email %>"><%= @organization.email %></a></strong>
   </body>

--- a/app/views/organization_mailer/create_new_org_and_admin.html.erb
+++ b/app/views/organization_mailer/create_new_org_and_admin.html.erb
@@ -7,7 +7,7 @@
     <h1><%= @user.first_name %>, thank you for registering <%= @organization.name %> with Homeward Tails</h1>
     
     <p>
-      You can access your site at: <%= link_to "#{root_url}#{@organization.slug}", home_index_url(script_name: "#{@organization.slug}"), target: "_blank" %>
+      You can access your site at: <%= link_to "#{root_url}#{@organization.slug}", home_index_url(script_name: "/#{@organization.slug}"), target: "_blank" %>
     </p>
 
     <p>
@@ -23,7 +23,7 @@
     </p>
 
     <p>
-      <%= link_to "Log-in", new_user_session_url(script_name: "#{@organization.slug}"), target: "_blank" %>
+      <%= link_to "Log-in", new_user_session_url(script_name: "/#{@organization.slug}"), target: "_blank" %>
     </p>
 
     <strong>Homeward Tails Team</strong>

--- a/app/views/sign_up_mailer/adopter_welcome_email.html.erb
+++ b/app/views/sign_up_mailer/adopter_welcome_email.html.erb
@@ -12,17 +12,17 @@
       <li>Complete the adopter questionnaire</li>
       <li>Browse available pets and find one that is a good fit for you</li>
       <li>Click on the 'Apply' button on your favourite pet's page</li>
-      <li>Check the Applications page for a summary of your applications</li>
+      <li>Check your Dashboard > Applications page for a summary of your applications</li>
       <li>Await contact from us for a conversation about you, the pet, and the process</li>
     </ol>
 
     <strong>Still have questions?</strong>
-    <p>Check out the <%= link_to "FAQ page", faq_index_url(script_name: "#{@organization.slug}"), target: "_blank" %>.</p>
+    <p>Check out the <%= link_to "FAQ page", faq_index_url(script_name: "/#{@organization.slug}"), target: "_blank" %>.</p>
     <p>Again, thank you for signing up! People like you help these pets live their best life.</p>
 
-    <strong>- <%= @organization.name %> Team</strong>
     <br>
     <a href=<% @org_root %>>www.homewardtails.org/<%= @organization.slug %></a>
+    <br>
     <br>
     <strong>Please do not reply directly to this email. You must contact <%= @organization.name %> directly at <a href="mailto:<%= @organization.email %>"><%= @organization.email %></a></strong>
   </body>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # devise mailer (e.g. reset password)
-  config.action_mailer.default_url_options = {host: "https://www.homewardtails.org/"}
+  config.action_mailer.default_url_options = {host: "https://www.homewardtails.org"}
   config.action_mailer.default_options = {from: "homewardtails@gmail.com"}
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION

# ✍️ Description
I removed the `/` from where we were defining script name in mailers, but I realized I just needed to remove the trailing `/` in the config...this fixes that mistake and shoud fix all links in production e.g., the forgot password redirect to reset password.


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
