### PR TITLE
Disabled link for adopted pets under adoption applications

### DIFF
--- a/app/views/organizations/adopter_fosterer/adopter_applications/_application_cards.html.erb
+++ b/app/views/organizations/adopter_fosterer/adopter_applications/_application_cards.html.erb
@@ -6,7 +6,7 @@
   <ul class="list-group list-group-flush">
     <li class="list-group-item d-flex justify-content-between">
       <h5 class="card-title mb-0 fs-3">
-        <%= link_to pet.name, adoptable_pet_path(pet) %>
+        <%= link_to_unless pet.is_adopted?, pet.name, adoptable_pet_path(pet) %>
       </h5>
     </li>
     <% li_classes = %w[list-group-item text-secondary] %>

--- a/app/views/organizations/adopter_fosterer/adopter_applications/_applications_table.html.erb
+++ b/app/views/organizations/adopter_fosterer/adopter_applications/_applications_table.html.erb
@@ -24,7 +24,7 @@
               'coming_soon.jpg', class: 'rounded-3', style: "height: 50px; width: 50px; object-fit: cover;") %>
               <div class="ms-3">
                 <h4 class="mb-0">
-                  <%= link_to pet.name, adoptable_pet_path(pet) %>
+                  <%= link_to_unless pet.is_adopted?, pet.name, adoptable_pet_path(pet) %>
                 </h4>
               </div>
             </div>


### PR DESCRIPTION
Resolves #1056 
http://localhost:3000/alta/adopter_fosterer/applications

# ✍️ Description
I disabled the link to a pet's profile under the adoption applications if the adoption has been made. I utilized the method is_adopted? to simplify this issue. I did not write any new tests.

# 📷 Screenshots/Demos
<img width="509" alt="Screenshot 2024-12-12 at 12 53 22 PM" src="https://github.com/user-attachments/assets/206a2330-bcf8-4b4a-bf0e-1744a70c4dc9" />

