### PR TITLE
Remove action column in staff/staff and staff/adopter tables

### DIFF
--- a/app/views/organizations/staff/adopters/_adopter_table.html.erb
+++ b/app/views/organizations/staff/adopters/_adopter_table.html.erb
@@ -6,7 +6,6 @@
         <tr>
           <th scope="col"><%= t(:name) %></th>
           <th scope="col"><%= t(:joined_at) %></th>
-          <th scope="col"><%= t(:action) %></th>
         </tr>
       </thead>
       <tbody>
@@ -25,21 +24,6 @@
             </td>
             <td>
               <%= adopter.created_at.strftime("%d %B, %Y") %>
-            </td>
-            <td>
-              <div class="hstack gap-4">
-                <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
-                <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
-                <span class="dropdown dropstart">
-                  <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
-                    <i class="fe fe-more-vertical"></i>
-                  </a>
-                  <span class="dropdown-menu">
-                    <span class="dropdown-header"><%=t(:settings) %></span>
-                    <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> <%= t("general.edit") %></a>
-                  </span>
-                </span>
-              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/organizations/staff/staff/_staff_table.html.erb
+++ b/app/views/organizations/staff/staff/_staff_table.html.erb
@@ -8,7 +8,6 @@
           <th scope="col"><%= t(:role) %></th>
           <th scope="col"><%= t(:joined_at) %></th>
           <th class="text-center" scope="col"><%= t(:deactivate) %></th>
-          <th scope="col"><%= t(:action) %></th>
         </tr>
       </thead>
       <tbody>
@@ -33,21 +32,6 @@
             </td>
             <td>
               <%= render "deactivate_toggle", staff: staff %>
-            </td>
-            <td>
-              <div class="hstack gap-4">
-                <a href="#" class="fe fe-mail text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Message" data-bs-original-title="Message"></a>
-                <a href="#" class="text-muted" data-bs-toggle="tooltip" data-placement="top" aria-label="Delete" data-bs-original-title="Delete"><i class="fe fe-trash"></i></a>
-                <span class="dropdown dropstart">
-                  <a class="btn-icon btn btn-ghost btn-sm rounded-circle" href="#" role="button" data-bs-toggle="dropdown" data-bs-offset="-20,20" aria-expanded="false">
-                    <i class="fe fe-more-vertical"></i>
-                  </a>
-                  <span class="dropdown-menu">
-                    <span class="dropdown-header"><%= t(:settings) %></span>
-                    <a class="dropdown-item" href="#"><i class="fe fe-edit dropdown-item-icon"></i> <%= t("general.edit") %></a>
-                  </span>
-                </span>
-              </div>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/homeward-tails/issues/1223

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This change removes the action column in the staff/staff and staff/adopters tables, which are currently not doing anything.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
<img width="1718" alt="Screenshot 2024-12-13 at 5 30 11 PM" src="https://github.com/user-attachments/assets/a7e3cf52-e521-432f-b02d-5573f20eb841" />
<img width="1721" alt="Screenshot 2024-12-13 at 5 30 25 PM" src="https://github.com/user-attachments/assets/c185132b-24e4-4a5b-89ce-5af52344718d" />

