### PR TITLE
fix: switch footer title to Homeward Tails #1260

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,7 +174,7 @@ en:
   layouts:
     shared:
       footer:
-        title: "Pet Rescue"
+        title: "Homeward Tails"
         call: "If you are a pet adoption or foster organization and want a website like this one, for free,"
         action: "Click Here"
         company: "Company"


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/homeward-tails/issues/1260

# ✍️ Description
Updates the footer title from Pet Rescue to Homeward Tails

# 📷 Screenshots/Demos

<img width="1468" alt="Screenshot 2024-12-15 at 10 31 29 PM" src="https://github.com/user-attachments/assets/10ba9f3a-e732-4b31-82ab-7a52aae6677f" />
