### PR TITLE
Use asset_path helper for banner background image

### DIFF
--- a/app/views/layouts/adopter_foster_dashboard.html.erb
+++ b/app/views/layouts/adopter_foster_dashboard.html.erb
@@ -13,7 +13,7 @@
             <!-- User info -->
             <div class="col-xl-12 col-lg-12 col-md-12 col-12">
               <!-- Bg -->
-              <div class="rounded-top" style="background: url('/assets/background/profile-bg.jpg') no-repeat; background-size: cover; height: 100px;"></div>
+              <div class="rounded-top" style="background: url('<%= asset_path('background/profile-bg.jpg') %>') no-repeat; background-size: cover; height: 100px;"></div>
               <div class="card px-4 pt-2 pb-4 shadow-sm rounded-top-0 rounded-bottom-0 rounded-bottom-md-2">
                 <div class="d-flex align-items-end justify-content-between">
                   <div class="d-flex align-items-center">


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/homeward-tails/issues/1226

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Used the `asset_path` helper to set the background image of the banner div.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
<img width="1720" alt="Screenshot 2024-12-17 at 2 54 25 AM" src="https://github.com/user-attachments/assets/aca21332-bbb9-49a3-bea9-cf1e46fe181d" />
