### PR TITLE
Reorder nav items for mobile and hide org name

### DIFF
--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -1,15 +1,5 @@
 <nav class="navbar navbar-expand-lg bg-transparent shadow-none px-0 py-3">
   <div class="container-fluid px-4">
-    <div class="d-flex gap-2">
-      <% if Current.organization.avatar.attached? %>
-        <%= image_tag Current.organization.avatar, alt: current_organization_name, title: current_organization_name, height: 30 %>
-      <% end %>
-
-      <%= link_to home_index_path, class: 'navbar-brand fw-bold text-black' do %>
-        <%= Current.organization.name %>
-      <% end %>
-    </div>
-
     <div class="d-flex align-items-center order-lg-3">
       <div>
         <button class="navbar-toggler collapsed me-1" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-default3" aria-controls="navbar-default3" aria-expanded="false" aria-label="Toggle navigation">
@@ -27,6 +17,16 @@
         <li class="nav-item d-block">
           <%= button_to t('.log_out'), destroy_user_session_path, method: :delete, data: { turbo: false }, class: 'ms-2 btn btn-primary' %>
         </li>
+      <% end %>
+    </div>
+
+    <div class="d-flex gap-2">
+      <% if Current.organization.avatar.attached? %>
+        <%= image_tag Current.organization.avatar, alt: current_organization_name, title: current_organization_name, height: 30 %>
+      <% end %>
+
+      <%= link_to home_index_path, class: 'navbar-brand fw-bold text-black d-none d-sm-block' do %>
+        <%= Current.organization.name %>
       <% end %>
     </div>
 


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/homeward-tails/issues/1236

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Reordered nav items to be mobile first and hid the organization name on xs screens.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

https://github.com/user-attachments/assets/bcc5ea77-8dfc-4c40-b500-cdd3208d7bed


