### PR TITLE
update the custom form flow

### DIFF
--- a/app/views/organizations/adopter_fosterer/external_form/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/external_form/index.html.erb
@@ -1,32 +1,32 @@
-<div class="d-flex flex-column align-items-center mb-4">
-  <div class="my-4 mx-8">
-    <% if params[:dashboard] %>
-
-      <% if current_user.person.latest_form_submission.present? %>
-        <p class="fw-bold mb-0"><%= t('organizations.adopter_fosterer.form_instructions.previous_answers') %> <%= link_to t('general.here'), adopter_fosterer_form_answers_path %>.</p>
-        <p><%= t('organizations.adopter_fosterer.form_instructions.update_form_answers') %></p>
+<section class="container d-flex flex-column py-6">
+  <div class="row justify-content-center gap-6">
+  <div class="col-8">
+      <% if params[:dashboard] %>
+        <% if current_user.person.latest_form_submission.present? %>
+          <p class="fw-bold mb-0"><%= t('organizations.adopter_fosterer.form_instructions.previous_answers') %> <%= link_to t('general.here'), adopter_fosterer_form_answers_path %>.</p>
+          <p><%= t('organizations.adopter_fosterer.form_instructions.update_form_answers') %></p>
+        <% else %>
+          <p><%= t("organizations.adopter_fosterer.form_instructions.dashboard", user_email: current_user.email) %></p>
+        <% end %>
       <% else %>
-        <p><%= t("organizations.adopter_fosterer.form_instructions.dashboard", user_email: current_user.email) %></p>
-      <% end %>
-
-  <% else %>
-      <p><%= t(
-          "organizations.adopter_fosterer.form_instructions.index",
-          organization_name: Current.tenant.name,
-        ) %></p>
+        <div>
+          <p class="fw-bold"><%= t(
+              "organizations.adopter_fosterer.form_instructions.index",
+              organization_name: Current.tenant.name,
+              email: current_user.email
+            ) %></p>
+          <%= link_to "Go to my dashboard", adopter_fosterer_dashboard_index_path, class: "btn btn-primary" %>
+        </div>
     <% end %>
-    <div class="d-flex justify-content-end gap-2 pb-2">
-      <%= link_to " #{t("general.view")} #{t("general.dogs")}",
-      adoptable_pets_path(species: "dog"),
-      class: "btn btn-primary" %>
-      <%= link_to " #{t("general.view")} #{t("general.cats")}",
-      adoptable_pets_path(species: "cat"),
-      class: "btn btn-primary" %>
     </div>
+
+    <div class="row">
+      <iframe id="external-form"
+        src=<%= @form_url%>
+        width="90%"
+        height="645"
+        >Loading…</iframe>
+    </div>
+
   </div>
-  <iframe id="external-form"
-    src=<%= @form_url%>
-    width="90%" 
-    height="645"
-    >Loading…</iframe>
-</div>
+</section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -733,7 +733,7 @@ en:
           header: "Welcome to %{organization_name}!"
           body_text: "At %{organization_name}, we’re dedicated to rescuing, rehabilitating, and rehoming animals in need. Your support helps us provide care, love, and hope to these pets until they find their forever homes."
       form_instructions:
-        index: "Please complete this form using the same email address you signed up with. %{organization_name} needs this information in order to process your application(s)."
+        index: "Please complete this form using the same email address you signed up with (%{email}). %{organization_name} needs this information in order to process your application(s). If you do not complete this form now, you can do so later via the 'Form' link in your dashboard"
         previous_answers: "You have already completed this form. View your responses"
         update_form_answers: "Please only submit this form again if your details have changed and need updating."
         dashboard: "Please complete this form so we have sufficient information to begin processing your adoption applications. Please ensure to use the same email address in the form as you did to register on this website (%{user_email})."


### PR DESCRIPTION
# 🔗 Issue
It didn't feel right the way we had the browse pets buttons under the iframe form after signing up. So I have updated to go to include a button to go to dashboard instead, and added more detail to the text. 

New sign up
<img width="1616" alt="image" src="https://github.com/user-attachments/assets/ca9bd1af-c09f-43dc-b7cb-76c73a6881a9" />

When form has not been submitted or imported
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/bab3c25a-746d-4083-96dd-4633fc164f9a" />


When form has been submitted and imported
<img width="1393" alt="image" src="https://github.com/user-attachments/assets/c36259c3-f785-44da-a078-99290a0c660e" />

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
