### PR TITLE
Issue #1287: Fixing input widths for org account request

### DIFF
--- a/app/views/shared/_location_fields.html.erb
+++ b/app/views/shared/_location_fields.html.erb
@@ -1,4 +1,5 @@
 <!-- Country Select -->
+<div class="form-group w-100">
 <%= form.select :country,
                 COUNTRIES_STATES.keys.index_with { |abbr| COUNTRIES_STATES.dig(abbr, :name) }.invert,
                 { prompt: "Please select" },
@@ -9,7 +10,10 @@
                   required: true,
                   class: 'form-control'
                 }  %>
+</div>
+
 <!-- Province/State Select -->
+<div class="form-group w-100">
 <%= form.select :province_state,
                 form.object.country.present? ? 
                 COUNTRIES_STATES.dig(form.object.country.to_sym, :states)&.map { |abbr, name| [:name, abbr] } : [],
@@ -19,7 +23,11 @@
                   required: true,
                   class: 'form-control'
                 }  %>
+</div>
+
 <!-- City/Town Text Field -->
+<div class="form-group w-100">
 <%= form.text_field :city_town,
                     required: true,
                     class: "form-control" %>
+</div>


### PR DESCRIPTION
# 🔗 Issue
[Original Issue](https://github.com/rubyforgood/homeward-tails/issues/1287)

# ✍️ Description
Resizes input columns in shared `_location_fields.html.erb` partial to make the width consistent.

# 📷 Screenshots/Demos
<img width="770" alt="image" src="https://github.com/user-attachments/assets/6642a37d-a2d5-4919-9a14-bea6807afa2d" />
