### PR TITLE
Increase size of the dashboard for adopters to be fluid to take advantage of viewport space

### DIFF
--- a/app/views/layouts/adopter_foster_dashboard.html.erb
+++ b/app/views/layouts/adopter_foster_dashboard.html.erb
@@ -7,8 +7,8 @@
 
     <!-- Page Content -->
     <main>
-      <section class="pt-5 pb-5">
-        <div class="container-lg">
+      <section class="pb-5">
+        <div class="container-fluid">
           <div class="row align-items-center">
             <!-- User info -->
             <div class="col-xl-12 col-lg-12 col-md-12 col-12">


### PR DESCRIPTION
# 🔗 Issue
N/A

# ✍️ Description
Thought we should increase the container of the adopter dashboard to be fluid. I think we are losing space for content via the container restricting the size of the dashboard. See snapshots below:


# 📷 Screenshots/Demos

![CleanShot 2024-12-25 at 13 06 56@2x](https://github.com/user-attachments/assets/1114e9d7-d2a3-4b46-bb75-2b73d29b9363)


![CleanShot 2024-12-25 at 13 06 43@2x](https://github.com/user-attachments/assets/d7c005c7-b4bb-4931-a05b-768209568e0b)

