### PR TITLE
Add unique species scope and test

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -95,6 +95,9 @@ class Pet < ApplicationRecord
     query.where(published: true).order(:breed).distinct.pluck(:breed)
   }
 
+  # Returns an array of unique species of an organization
+  scope :unique_species, -> { distinct.pluck(:species) }
+  
   attr_writer :toggle
 
   # check if pet has any applications with adoption pending status

--- a/test/models/pet_test.rb
+++ b/test/models/pet_test.rb
@@ -83,6 +83,19 @@ class PetTest < ActiveSupport::TestCase
         assert_not Pet.with_photo.include?(pet_without_image)
       end
     end
+
+    context ".unique_species" do
+      should "returns an array of unique species" do
+        create(:pet, species: "Dog")
+        create(:pet, species: "Cat")
+        create(:pet, species: "Dog")
+    
+        unique_species = Pet.unique_species
+    
+        assert_equal ["Cat", "Dog"], unique_species.sort
+        assert_equal 1, unique_species.count("Dog")
+      end
+    end
   end
 
   context "#has_adoption_pending?" do


### PR DESCRIPTION
# 🔗 Issue
#1081 [Issue Link](https://github.com/rubyforgood/homeward-tails/issues/1081)

# ✍️ Description
Added scope "unique_species"  of an ORG for future conditional rendering of species buttons. Simple test also added to make sure a single species isn't returned more than once. 

# 📷 Screenshots/Demos
<img width="513" alt="Screenshot 2024-12-27 at 7 39 03 PM" src="https://github.com/user-attachments/assets/af55fdd7-d9e6-437e-9cb5-0e86680ffe75" />

<img width="490" alt="Screenshot 2024-12-27 at 7 38 47 PM" src="https://github.com/user-attachments/assets/7994153d-ad2a-451d-96e6-0d01efe1ec6f" />
