### PR TITLE
Allow duplicate email between orgs

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,7 +29,7 @@
 #
 # Indexes
 #
-#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_email                 (email)
 #  index_users_on_invitation_token      (invitation_token) UNIQUE
 #  index_users_on_invited_by            (invited_by_type,invited_by_id)
 #  index_users_on_invited_by_id         (invited_by_id)
@@ -60,7 +60,7 @@ class User < ApplicationRecord
     end
   end
 
-  devise :invitable, :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable
+  devise :invitable, :database_authenticatable, :registerable, :recoverable, :rememberable
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,17 +17,7 @@
             <h1 class="mb-1 fw-bold">Sign up</h1>
           </div>
 
-          <div>
-            <% if flash[:alert] %>
-              <div class="alert alert-danger" role="alert">
-                <%= alert %>
-              </div>
-            <% end%>
-          </div>
           <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-
-            <%= render "devise/shared/error_messages", resource: resource %>
-
             <div class="form-group mb-3 bigger">
               <%= f.email_field :email,
                                 autofocus: true,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -28,10 +28,6 @@
 
             <%= render "devise/shared/error_messages", resource: resource %>
 
-            <%= f.fields_for :adopter_foster_account do |fields| %>
-              <%= fields.hidden_field :user_id %>
-            <% end %>
-
             <div class="form-group mb-3 bigger">
               <%= f.email_field :email,
                                 autofocus: true,

--- a/db/migrate/20250106022958_remove_unique_index_on_users_email.rb
+++ b/db/migrate/20250106022958_remove_unique_index_on_users_email.rb
@@ -2,7 +2,7 @@ class RemoveUniqueIndexOnUsersEmail < ActiveRecord::Migration[8.0]
   disable_ddl_transaction!
 
   def change
-      remove_index :users, name: "index_users_on_email"
-      add_index :users, :email, algorithm: :concurrently
+    remove_index :users, name: "index_users_on_email"
+    add_index :users, :email, algorithm: :concurrently
   end
 end

--- a/db/migrate/20250106022958_remove_unique_index_on_users_email.rb
+++ b/db/migrate/20250106022958_remove_unique_index_on_users_email.rb
@@ -1,0 +1,8 @@
+class RemoveUniqueIndexOnUsersEmail < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+      remove_index :users, name: "index_users_on_email"
+      add_index :users, :email, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_28_004147) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_06_022958) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -282,7 +282,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_28_004147) do
     t.datetime "deactivated_at"
     t.string "provider"
     t.string "uid"
-    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["email"], name: "index_users_on_email"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by"


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
Per [this discussion](https://rubyforgood.slack.com/archives/C05JXC199M2/p1736129153581599) I have put up this PR as a proposal to allow users to register across organizations with the same email address. This will create separate user records scoped to each org, which I think is fine, considering the organizations do not have any cross functionality or data sharing. This is the simplest approach to allow a user to register on multiple pet rescue orgs, and is likey a need given we might have multiple orgs using our app on the Baja peninsula alone. 

We will still ensure uniqueness on email under the Org scope with this validation that already exists on User
```
validates :email, presence: true, uniqueness: {scope: :organization_id}, format: {
    with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
  }
```


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
