### PR TITLE
Issue #1319 - Update file type description and add CSV file type validation

### DIFF
--- a/app/controllers/concerns/attachment_manageable.rb
+++ b/app/controllers/concerns/attachment_manageable.rb
@@ -24,4 +24,10 @@ module AttachmentManageable
       render turbo_stream: turbo_stream.replace("flash", partial: "layouts/shared/flash_messages")
     end
   end
+
+  def handle_incorrect_file_format_when_csv_expected
+    unless params[:files].content_type == "text/csv"
+      redirect_to staff_external_form_upload_index_path, alert: "File must be a CSV."
+    end
+  end
 end

--- a/app/controllers/concerns/attachment_manageable.rb
+++ b/app/controllers/concerns/attachment_manageable.rb
@@ -26,7 +26,7 @@ module AttachmentManageable
   end
 
   def handle_incorrect_file_format_when_csv_expected
-    unless params[:files].content_type == "text/csv"
+    unless params[:files]&.content_type == "text/csv"
       redirect_to staff_external_form_upload_index_path, alert: "File must be a CSV."
     end
   end

--- a/app/controllers/organizations/staff/external_form_upload_controller.rb
+++ b/app/controllers/organizations/staff/external_form_upload_controller.rb
@@ -12,10 +12,11 @@ module Organizations
       def create
         authorize! :external_form_upload, context: {organization: Current.organization}
         file = params[:files]
+
         unless file.content_type == "text/csv"
           redirect_to staff_external_form_upload_index_path, alert: "File must be a CSV."
         end
-        
+
         @blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: file.original_filename)
 
         CsvImportJob.perform_later(@blob.signed_id, current_user.id)

--- a/app/controllers/organizations/staff/external_form_upload_controller.rb
+++ b/app/controllers/organizations/staff/external_form_upload_controller.rb
@@ -3,7 +3,8 @@ module Organizations
     class ExternalFormUploadController < Organizations::BaseController
       include AttachmentManageable
       layout "dashboard"
-      before_action :validate_attachment, only: [:create]
+      before_action :allow_only_one_attachment, only: [:create]
+      before_action :handle_incorrect_file_format_when_csv_expected, only: [:create]
 
       def index
         authorize! :external_form_upload, context: {organization: Current.organization}
@@ -21,11 +22,6 @@ module Organizations
         respond_to do |format|
           format.turbo_stream
         end
-      end
-
-      def validate_attachment
-        allow_only_one_attachment
-        handle_incorrect_file_format_when_csv_expected
       end
     end
   end

--- a/app/controllers/organizations/staff/external_form_upload_controller.rb
+++ b/app/controllers/organizations/staff/external_form_upload_controller.rb
@@ -12,6 +12,10 @@ module Organizations
       def create
         authorize! :external_form_upload, context: {organization: Current.organization}
         file = params[:files]
+        unless file.content_type == "text/csv"
+          redirect_to staff_external_form_upload_index_path, alert: "File must be a CSV."
+        end
+        
         @blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: file.original_filename)
 
         CsvImportJob.perform_later(@blob.signed_id, current_user.id)

--- a/app/views/organizations/staff/external_form_upload/index.html.erb
+++ b/app/views/organizations/staff/external_form_upload/index.html.erb
@@ -11,7 +11,7 @@
           title: "Files",
           url: staff_external_form_upload_index_path,
           multiple: false,
-          attachment_type: "files" %>
+          attachment_type: "csv" %>
         </div>
       </div>
     </section>

--- a/app/views/organizations/staff/shared/_attachment_form.html.erb
+++ b/app/views/organizations/staff/shared/_attachment_form.html.erb
@@ -18,9 +18,11 @@
                           hide_label: true %>
           <small class="form-text text-muted">
             <% if attachment_type == 'files' %>
-              File must be .csv under 2MB.
+              Files must be .pdf, .png, or .jpeg under 2MB.
             <% elsif attachment_type == 'images' %>
               Images must be .jpg or .png under 1MB.
+            <% elsif attachment_type == 'csv' %>
+              File must be a .csv under 2MB.
             <% end %>
           </small>
         </div>

--- a/app/views/organizations/staff/shared/_attachment_form.html.erb
+++ b/app/views/organizations/staff/shared/_attachment_form.html.erb
@@ -18,7 +18,7 @@
                           hide_label: true %>
           <small class="form-text text-muted">
             <% if attachment_type == 'files' %>
-              Files must be .pdf, .png, or .jpeg under 2MB.
+              File must be .csv under 2MB.
             <% elsif attachment_type == 'images' %>
               Images must be .jpg or .png under 1MB.
             <% end %>


### PR DESCRIPTION
# 🔗 Issue
[Original Issue](https://github.com/rubyforgood/homeward-tails/issues/1319)

# ✍️ Description
- Updates text under upload input to inform user that only CSV files will be accepted
- Adds a validation within the `create` action of the controller to display an alert if user uploads a file type other than CSV.

# 📷 Screenshots/Demos
_New copy and error message on top_
<img width="790" alt="image" src="https://github.com/user-attachments/assets/48bbdaf7-aaa9-481a-8e25-e4ac5c2a02f5" />
