### PR TITLE
Update: User Registration Redirect Path

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -64,6 +64,19 @@ class RegistrationsController < Devise::RegistrationsController
       :avatar)
   end
 
+  def after_update_path_for(resource)
+    role = resource.roles.find_by(resource_id: Current.organization.id)
+
+    case role&.name
+    when "adopter", "fosterer"
+      adopter_fosterer_dashboard_index_path
+    when "admin", "super_admin"
+      staff_dashboard_index_path
+    else
+      root_path
+    end
+  end
+
   def after_sign_up_path_for(resource)
     return root_path unless allowed_to?(:index?, with: Organizations::AdopterFosterDashboardPolicy, context: {organization: Current.organization})
 

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -29,4 +29,27 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
     get edit_user_registration_url(script_name: "/#{organization.slug}")
     assert_select "nav.navbar-vertical", 0
   end
+
+  test "should redirect to adopter foster dashboard when updated" do
+    user = create(:adopter_fosterer, password: "123456")
+    sign_in user
+
+    updated_params = {user: {first_name: "not the same name", current_password: "123456"}}
+
+    put user_registration_url, params: updated_params
+
+    assert_redirected_to adopter_fosterer_dashboard_index_url
+  end
+
+  test "should redirect to staff dashboard when updated" do
+    user = create(:admin, password: "123456")
+    organization = user.organization
+    sign_in user
+
+    updated_params = {user: {first_name: "Sean", current_password: "123456"}}
+
+    put user_registration_url(script_name: "/#{organization.slug}"), params: updated_params
+
+    assert_redirected_to staff_dashboard_index_url
+  end
 end

--- a/test/system/registration_test.rb
+++ b/test/system/registration_test.rb
@@ -24,12 +24,12 @@ class RegistrationTest < ApplicationSystemTestCase
       assert_selector("div.invalid-feedback", text: "must be PNG or JPEG")
     end
 
-    should "direct to home index path with valid upload" do
+    should "direct to staff dashboard path with valid upload" do
       attach_file("Attach picture", Rails.root + "test/fixtures/files/test.png")
       fill_in "Current password", with: @user.password
       click_on "Update"
 
-      assert has_current_path?(home_index_path)
+      assert has_current_path?(staff_dashboard_index_path)
     end
   end
 end


### PR DESCRIPTION
# 🔗 Issue
#1227 

# ✍️ Description
    This update utilizes Devise's after_update_path_for method to handle
    user redirection after updating their registration.

    If the user is part of the adopter or fosterer roster, and associated
    with a valid organization they will be redirected to their adopter/fosterer dashboard.

    If the user is an admin or super admin, and associated with a valid
    organization they will be redirected to their staff dashboard.

    If neither condition is met, the user will be redirected to the root path.

    Adds: Controller tests for user registration updates:
    Test case for adopter/fosterer user redirection.
    Test case for staff user redirection.

    Adds: update on registration test file to account for new update redirect


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
