### PR TITLE
fix the param name and callbacks

### DIFF
--- a/app/controllers/concerns/attachment_manageable.rb
+++ b/app/controllers/concerns/attachment_manageable.rb
@@ -1,6 +1,6 @@
 module AttachmentManageable
-  def allow_only_one_attachment
-    return unless params[:files].is_a?(Array)
+  def allow_only_one_csv_attachment
+    return unless params[:csv].is_a?(Array)
 
     flash.now[:alert] = t("attachment_manageable.upload_limit_exceeded")
     render turbo_stream: turbo_stream.replace("flash", partial: "layouts/shared/flash_messages")
@@ -26,8 +26,8 @@ module AttachmentManageable
   end
 
   def handle_incorrect_file_format_when_csv_expected
-    unless params[:files]&.content_type == "text/csv"
-      redirect_to staff_external_form_upload_index_path, alert: "File must be a CSV."
+    unless params[:csv]&.content_type == "text/csv"
+      redirect_to staff_external_form_upload_index_path, alert: t("attachment_manageable.must_be_csv")
     end
   end
 end

--- a/app/controllers/organizations/staff/external_form_upload_controller.rb
+++ b/app/controllers/organizations/staff/external_form_upload_controller.rb
@@ -3,7 +3,8 @@ module Organizations
     class ExternalFormUploadController < Organizations::BaseController
       include AttachmentManageable
       layout "dashboard"
-      before_action :allow_only_one_attachment, only: [:create]
+
+      before_action :allow_only_one_csv_attachment, only: [:create]
       before_action :handle_incorrect_file_format_when_csv_expected, only: [:create]
 
       def index
@@ -12,7 +13,7 @@ module Organizations
 
       def create
         authorize! :external_form_upload, context: {organization: Current.organization}
-        file = params[:files]
+        file = params[:csv]
 
         @blob = ActiveStorage::Blob.create_and_upload!(io: file, filename: file.original_filename)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -776,3 +776,4 @@ en:
   attachment_manageable:
     upload_limit_exceeded: "Upload limit exceeded: Only one file allowed."
     attachment_missing: "Please select a file to attach."
+    must_be_csv: "File format must be .csv"

--- a/test/controllers/organizations/staff/external_form_upload_controller_test.rb
+++ b/test/controllers/organizations/staff/external_form_upload_controller_test.rb
@@ -5,7 +5,7 @@ module Organizations
     class ExternalFormUploadControllerTest < ActionDispatch::IntegrationTest
       setup do
         file = fixture_file_upload("google_form_sample.csv", "text/csv")
-        @params = {files: file}
+        @params = {csv: file}
         admin = create(:admin)
         sign_in admin
       end


### PR DESCRIPTION
# 🔗 Issue
Fixes a bug caused by `params[:files]` after updating the upload form to send `params[:csv]`. I prefer specifiying the file format because it helps separate from the other two attachment types we have: `files` and `images`.

<img width="1482" alt="image" src="https://github.com/user-attachments/assets/cb42dbba-39b3-4f69-970e-5b4cca36be32" />

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
