### PR TITLE
Update Redirect Behavior Based on Success of Pet Creation

### DIFF
--- a/app/controllers/organizations/staff/pets_controller.rb
+++ b/app/controllers/organizations/staff/pets_controller.rb
@@ -44,8 +44,8 @@ class Organizations::Staff::PetsController < Organizations::BaseController
     if @pet.persisted?
       redirect_to staff_pet_path(@pet), notice: t(".success")
     else
-      flash[:alert] = t(".error")
-      redirect_to staff_pets_path
+      flash.now[:alert] = t(".error")
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/organizations/staff/pets_controller.rb
+++ b/app/controllers/organizations/staff/pets_controller.rb
@@ -42,10 +42,10 @@ class Organizations::Staff::PetsController < Organizations::BaseController
     end
 
     if @pet.persisted?
-      redirect_to staff_pets_path, notice: t(".success")
+      redirect_to staff_pet_path(@pet), notice: t(".success")
     else
-      flash.now[:alert] = t(".error")
-      render :new, status: :unprocessable_entity
+      flash[:alert] = t(".error")
+      redirect_to staff_pets_path
     end
   end
 


### PR DESCRIPTION
# 🔗 Issue
references https://github.com/rubyforgood/homeward-tails/issues/1335

# ✍️ Description
Currently, when a staff creates a pet, the redirect behavior is as follows: 

Successful Creation -> Redirect to Index 
Unsuccessful Creation -> Redirect to New

However, this is not the behavior that we want. Instead, the redirect behavior should be as follows: 

Successful Creation -> Redirect to Show for Newly Created Pet
Unsuccessful Creation -> Redirect to Index and Flash Error 

I did not add controller tests for this change as advised in the ticket, but I am happy to do so if it would be beneficial! 

# 📷 Screenshots/Demos
https://cassie.neetorecord.com/watch/072465a0442f283a16d7
