### PR TITLE
Change Link Name for Fosters Section on Sidenav

### DIFF
--- a/app/views/layouts/dashboard/_sidebar.html.erb
+++ b/app/views/layouts/dashboard/_sidebar.html.erb
@@ -32,7 +32,7 @@
       </li>
       <li class="nav-item">
         <%= active_link_to staff_manage_fosters_path, class: "nav-link" do %>
-          <i class="nav-icon fe fe-file-text me-2"></i>Fosters
+          <i class="nav-icon fe fe-file-text me-2"></i>In Foster
         <% end %>
       </li>
       <li class="nav-item">


### PR DESCRIPTION
# 🔗 Issue
references https://github.com/rubyforgood/homeward-tails/issues/1337

# ✍️ Description
Currently, the link to the Fosters section of the application is named "Fosters". 

![image](https://github.com/user-attachments/assets/f5b513f8-7128-4a4b-a1fd-6204592f1f25)

Instead, we would like the link text to be "In Foster"

# 📷 Screenshots/Demos

![Screenshot 2025-01-22 at 10 26 42 AM](https://github.com/user-attachments/assets/19759fd1-fd41-4b79-827f-3e69fb1823da)
