### PR TITLE
Docker Compose Sass Error

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: localhost
+  host: <%= ENV.fetch("DEFAULT_HOST", "localhost") %>
   username: <%= ENV.fetch("DATABASE_USERNAME") %>
   password: <%= ENV.fetch("DATABASE_PASSWORD") %>
   port: <%= ENV.fetch("DATABASE_PORT", "5432") %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,9 +48,9 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgres://${DATABASE_USERNAME:-postgres}:${DATABASE_PASSWORD:-password}@postgres:5432/petrescue_development
       DATABASE_USERNAME: ${DATABASE_USERNAME:-postgres}
       DATABASE_PASSWORD: ${DATABASE_PASSWORD:-password}
+      DEFAULT_HOST: postgres
       CABLE_HOST: cable
       QUEUE_HOST: queue
       RAILS_ENV: development
@@ -73,6 +73,8 @@ services:
     tty: true
     environment:
       RAILS_ENV: development
+      DATABASE_USERNAME: ${DATABASE_USERNAME:-postgres}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD:-password}
 
 volumes:
   postgres-data:


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
The sass service in docker was getting an error due to missing missing env variables. Updated accordingly.

I've also removed the `DATABASE_URL` variable. `ENV['DATABASE_URL']` is merged with and/or takes precedence over what is defined in `database.yml` ( [connection preference](https://guides.rubyonrails.org/configuring.html#connection-preference) ). 

Prior to #1353 , the primary database `postgres` was using `DATABASE_URL` to set the port and the db's `cable` and `queue` were using the default port 5432 from the postgres adapter. We are now explicitly defining ports etc. in `database.yml`  so I feel it make sense to keep in all on one place. This required adding a default host variable for docker to connect correctly.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
