### PR TITLE
Development Image Errors: Attach same blob to each pet

### DIFF
--- a/db/seeds/01_alta.rb
+++ b/db/seeds/01_alta.rb
@@ -192,6 +192,12 @@ ActsAsTenant.with_tenant(@organization) do
   )
 
   path = Rails.root.join("app", "assets", "images", "hero.jpg")
+  blob = ActiveStorage::Blob.create_and_upload!(
+    io: File.open(path),
+    filename: "hero.jpg",
+    content_type: "image/jpeg"
+  )
+
   from_weight = [5, 10, 20, 30, 40, 50, 60].sample
 
   50.times do
@@ -211,7 +217,7 @@ ActsAsTenant.with_tenant(@organization) do
       placement_type: Pet.placement_types.values.sample,
       published: true
     )
-    pet.images.attach(io: File.open(path), filename: "hero.jpg")
+    pet.images.attach(blob)
 
     due_dates = [Date.today - 1.day, Date.today, Date.today + 30.days]
     DefaultPetTask.all.each_with_index do |task, index|

--- a/db/seeds/02_baja.rb
+++ b/db/seeds/02_baja.rb
@@ -145,6 +145,12 @@ ActsAsTenant.with_tenant(@organization) do
   end
 
   path = Rails.root.join("app", "assets", "images", "hero.jpg")
+  blob = ActiveStorage::Blob.create_and_upload!(
+    io: File.open(path),
+    filename: "hero.jpg",
+    content_type: "image/jpeg"
+  )
+
   from_weight = [5, 10, 20, 30, 40, 50, 60].sample
 
   25.times do
@@ -164,7 +170,7 @@ ActsAsTenant.with_tenant(@organization) do
       placement_type: Pet.placement_types.values.sample,
       published: true
     )
-    pet.images.attach(io: File.open(path), filename: "hero.jpg")
+    pet.images.attach(blob)
 
     due_dates = [Date.today - 1.day, Date.today, Date.today + 30.days]
     DefaultPetTask.all.each_with_index do |task, index|


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
#1365 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This eliminates the random broken pet images in development however it does not address the root cause. I created an issue which we might consider keeping open in case someone can address the real issue and/or we get the same issue in production when more data is being added.

Overall I still think this is a good change for the seed data. This creates a single blob from a single image file. Each pet then associates with that one blob. Currently we take the single `hero.jpg` image and create/upload a blob and new file on disk over and over again for each pet even though it is the same image. Of course this is not what we do in production per say, but I don't think we need 200 different dummy images just for seed data. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
