### PR TITLE
Deployment Failure Fix: Use default env var db names

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -6,8 +6,8 @@
 #
 KAMAL_REGISTRY_PASSWORD=$(RAILS_ENV=production KEY=deploy,kamal_registry_password, bin/rails credentials:read)
 DB_HOST=$(RAILS_ENV=production KEY=deploy,db_host, bin/rails credentials:read)
-DB_USER=$(RAILS_ENV=production KEY=deploy,db_user, bin/rails credentials:read)
-DB_PASSWORD=$(RAILS_ENV=production KEY=deploy,db_password, bin/rails credentials:read)
+DATABASE_USERNAME=$(RAILS_ENV=production KEY=deploy,db_user, bin/rails credentials:read)
+DATABASE_PASSWORD=$(RAILS_ENV=production KEY=deploy,db_password, bin/rails credentials:read)
 
 # Option 2: Read secrets via a command
 RAILS_MASTER_KEY=$(cat config/credentials/production.key)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN echo "Bust"
 
 # Install base packages
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y curl libjemalloc2 libvips postgresql-client && \
+    apt-get install --no-install-recommends -y curl less libjemalloc2 libvips postgresql-client && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 # Install Node.js

--- a/config/database.yml
+++ b/config/database.yml
@@ -101,8 +101,6 @@ production:
   primary: &primary_production
     <<: *default
     host: <%= ENV["DB_HOST"] %>
-    username: <%= ENV["DB_USER"] %>
-    password: <%= ENV["DB_PASSWORD"] %>
     database: postgres
     timeout: 5000
   cable:

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -46,8 +46,8 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - DB_HOST
-    - DB_USER
-    - DB_PASSWORD
+    - DATABASE_USERNAME
+    - DATABASE_PASSWORD
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.
@@ -61,8 +61,12 @@ env:
 #
 aliases:
   shell: app exec --interactive --reuse "bash"
-  logs: app logs -f
   console: app exec -i --reuse "bin/rails console"
+  logs: app exec -i --reuse "less -n +F log/production.log"
+# Running "kamal logs" will start following the tail of the log file and
+# display more text as the file grows. "ctrl-c" to enter navigation. "F" to follow again.
+# Navigation - "j" up, "k" down, "q" quit, Search - "/" /foo, "n" next occurance, "N" previous
+# https://greenwoodsoftware.com/less/index.html
 
 # Use a different ssh user than root
 #


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Production deployment is [failing](https://github.com/rubyforgood/homeward-tails/actions/runs/13272488520/job/37054989476#step:7:9) after the recent env variable changes for the database connections. I've changed the Kamal secret variable names to match the naming convention used for the default db config. This should* work.

I also did a minor change to the kamal log alias we have defined. `kamal app logs` displays STDOUT but we are logging to production.log.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
