### PR TITLE
Add default db username and password back

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 PRECOMPILING=1 ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 PRECOMPILING=1 DATABASE_USERNAME=dummy ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 PRECOMPILING=1 DATABASE_USERNAME=dummy ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 PRECOMPILING=1 DATABASE_USERNAME=dummy DATABASE_PASSWORD=dummy ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 PRECOMPILING=1 DATABASE_USERNAME=dummy DATABASE_PASSWORD=dummy ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 PRECOMPILING=1 ./bin/rails assets:precompile
 
 # Final stage for app image
 FROM base

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,8 +18,8 @@ default: &default
   adapter: postgresql
   encoding: unicode
   host: <%= ENV.fetch("DEFAULT_HOST", "localhost") %>
-  username: <%= ENV.fetch("DATABASE_USERNAME") %>
-  password: <%= ENV.fetch("DATABASE_PASSWORD") %>
+  username: <%= ENV.fetch("DATABASE_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "password") %>
   port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
I am unable to figure out where in the kamal deployment `bin/rails` is being run which causes the failure when the env variables are not set. 

The assets:precompile was one location which I was able to replicate locally and resolve. I was able to deploy to production from my machine successfully. However, somewhere in the deployment flow, my local `DATABASE_USERNAME` was being read. When I removed it, the deployment failed the same as from the github [action.](https://github.com/rubyforgood/homeward-tails/actions/runs/13285027555/job/37091740951#step:7:8)

Adding the default username and password back to `database.yml` is the simplest solution at this time and removes the need to add dummy values in multiple places. This also removes the risk of someone mistakenly updating a dummy value with a secret and committing it. 

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
