### PR TITLE
Add Start and End Date to Foster Card - 1091

### DIFF
--- a/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
@@ -8,13 +8,19 @@
             <div class="col">
               <%= link_to adopter_fosterer_fostered_pet_files_path(fostered_pet.pet, pet_id: fostered_pet.pet.id), data: { turbo_frame: "pet_files", action: "click->card#selectCard" } do %>
                 <div class="card h-100 bg-white border-0 shadow-sm" data-card-target="card">
-                  <div class="card-body d-flex align-items-center">
+                  <div class="card-body d-flex align-items-center justify-content-around">
                     <div class="me-3 flex-shrink-0" style="width: 50px; height: 50px;">
                       <%= image_tag(fostered_pet.pet.images.attached? ? fostered_pet.pet.images.first : 'coming_soon.jpg', 
                                     class: 'rounded-circle', 
                                     style: "width: 100%; height: 100%; object-fit: cover;") %>
                     </div>
-                    <h5 class="card-title mb-0"><%= fostered_pet.pet.name %></h5>
+                    <h5 class="card-title mb-0 flex-grow-1 text-center"><%= fostered_pet.pet.name %></h5>
+                    <div class="fostered-dates">
+                      <div class="d-flex flex-column text-end">
+                        <h5 class="mb-1">Start Date: <%= fostered_pet.start_date.strftime("%m/%d/%y") %></h5>
+                        <h5 class="mb-0">End Date: <%= fostered_pet.end_date.strftime("%m/%d/%y") %></h5>
+                      </div>
+                    </div>
                   </div>
                 </div>
               <% end %>


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/homeward-tails/issues/1091

# ✍️ Description
Fosterers can view their fostered pets through the dashboard, and there is a card for each pet with their name and photo. 
However, it's not immediately clear when or for how long these pets were fostered (or are being fostered). It would be helpful to have this information visible at a glance, so we should add the start and end date to the foster's card. 

# 📷 Screenshots/Demos
Current: 

![Screenshot 2025-02-26 at 8 53 57 PM](https://github.com/user-attachments/assets/ea256dc1-2deb-48f8-b1df-e7a150781581)

After Date Range Addition: 

![Screenshot 2025-02-27 at 8 57 38 AM](https://github.com/user-attachments/assets/aa5ebd68-3a59-41f2-843d-e45bd9502a5e)

On Mobile: 

![Screenshot 2025-02-26 at 9 01 18 PM](https://github.com/user-attachments/assets/a3f1f799-a34f-4a0b-96fb-ad2326aad1a4)

