### PR TITLE
Include Upcoming Fosters on Fostered Pets Index - 1231

### DIFF
--- a/app/controllers/organizations/adopter_fosterer/fostered_pets_controller.rb
+++ b/app/controllers/organizations/adopter_fosterer/fostered_pets_controller.rb
@@ -5,7 +5,7 @@ module Organizations
       layout "adopter_foster_dashboard"
 
       def index
-        @fostered_pets = authorized_scope(Match.fosters.current, with: Organizations::AdopterFosterer::MatchPolicy)
+        @fostered_pets = authorized_scope(Match.fosters.current.or(Match.fosters.upcoming), with: Organizations::AdopterFosterer::MatchPolicy)
       end
 
       private

--- a/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
@@ -9,22 +9,25 @@
               <%= link_to adopter_fosterer_fostered_pet_files_path(fostered_pet.pet, pet_id: fostered_pet.pet.id), data: { turbo_frame: "pet_files", action: "click->card#selectCard" } do %>
                 <div class="card h-100 bg-white border-0 shadow-sm" data-card-target="card">
                   <div class="card-body d-flex flex-wrap flex-column flex-lg-row align-items-center justify-content-between gap-2">
-                    <div class="d-flex align-items-center flex-shrink-0" style="width: 50px; height: 50px;">
-                      <%= image_tag(
-                            fostered_pet.pet.images.attached? ? fostered_pet.pet.images.first : 'coming_soon.jpg',
-                            class: 'rounded-circle',
-                            style: "width: 100%; height: 100%; object-fit: cover;"
-                          ) %>
-                    </div>
-                    <h4 class="card-title mb-0 flex-grow-1 text-center">
-                      <%= fostered_pet.pet.name %>
-                    </h4>
-                    <div class="fostered-dates d-flex flex-column text-start">
-                      <div class="badge mb-2 <%= status_classes(fostered_pet.status) %>">
+                    <div class="d-flex flex-column align-items-center flex-shrink-0">
+                      <div style="width: 50px; height: 50px;">
+                        <%= image_tag(
+                              fostered_pet.pet.images.attached? ? fostered_pet.pet.images.first : 'coming_soon.jpg',
+                              class: 'rounded-circle',
+                              style: "width: 100%; height: 100%; object-fit: cover;"
+                            ) %>
+                      </div>
+                      <div class="badge mt-2 <%= status_classes(fostered_pet.status) %>">
                         <%= fostered_pet.status.to_s.titleize %>
                       </div>
+                    </div>
+
+                    <h3 class="card-title mb-0 flex-grow-1 text-center">
+                      <%= fostered_pet.pet.name %>
+                    </h3>
+                    <div class="fostered-dates d-flex flex-column text-start">
                       <h5 class="mb-1">Start: <%= fostered_pet.start_date.strftime("%m/%d/%y") %></h5>
-                      <h5 class="mb-0">End: <%= fostered_pet.end_date.strftime("%m/%d/%y") %></h5>
+                      <h5 class="mt-1">End: <%= fostered_pet.end_date.strftime("%m/%d/%y") %></h5>
                     </div>
                   </div>
                 </div>

--- a/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
@@ -8,24 +8,30 @@
             <div class="col">
               <%= link_to adopter_fosterer_fostered_pet_files_path(fostered_pet.pet, pet_id: fostered_pet.pet.id), data: { turbo_frame: "pet_files", action: "click->card#selectCard" } do %>
                 <div class="card h-100 bg-white border-0 shadow-sm" data-card-target="card">
-                  <div class="card-body d-flex align-items-center justify-content-around">
-                    <div class="me-3 flex-shrink-0" style="width: 50px; height: 50px;">
-                      <%= image_tag(fostered_pet.pet.images.attached? ? fostered_pet.pet.images.first : 'coming_soon.jpg', 
-                                    class: 'rounded-circle', 
-                                    style: "width: 100%; height: 100%; object-fit: cover;") %>
+                  <div class="card-body d-flex flex-wrap flex-column flex-lg-row align-items-center justify-content-between gap-2">
+                    <div class="d-flex align-items-center flex-shrink-0" style="width: 50px; height: 50px;">
+                      <%= image_tag(
+                            fostered_pet.pet.images.attached? ? fostered_pet.pet.images.first : 'coming_soon.jpg',
+                            class: 'rounded-circle',
+                            style: "width: 100%; height: 100%; object-fit: cover;"
+                          ) %>
                     </div>
-                    <h5 class="card-title mb-0 flex-grow-1 text-center"><%= fostered_pet.pet.name %></h5>
-                    <div class="fostered-dates">
-                      <div class="d-flex flex-column text-end">
-                        <h5 class="mb-1">Start Date: <%= fostered_pet.start_date.strftime("%m/%d/%y") %></h5>
-                        <h5 class="mb-0">End Date: <%= fostered_pet.end_date.strftime("%m/%d/%y") %></h5>
+                    <h3 class="card-title mb-0 flex-grow-1 text-center">
+                      <%= fostered_pet.pet.name %>
+                    </h3>
+                    <div class="fostered-dates d-flex flex-column text-start">
+                      <div class="badge mb-2 <%= status_classes(fostered_pet.status) %>">
+                        <%= fostered_pet.status.to_s.titleize %>
                       </div>
+                      <h5 class="mb-1">Start: <%= fostered_pet.start_date.strftime("%m/%d/%y") %></h5>
+                      <h5 class="mb-0">End: <%= fostered_pet.end_date.strftime("%m/%d/%y") %></h5>
                     </div>
                   </div>
                 </div>
               <% end %>
             </div>
-          <% end %>
+
+        <% end %>
         </div>
       <% else %>
         <%= render partial: "shared/empty_state", locals: {text: t(".empty_state")} %>

--- a/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
@@ -16,9 +16,9 @@
                             style: "width: 100%; height: 100%; object-fit: cover;"
                           ) %>
                     </div>
-                    <h3 class="card-title mb-0 flex-grow-1 text-center">
+                    <h4 class="card-title mb-0 flex-grow-1 text-center">
                       <%= fostered_pet.pet.name %>
-                    </h3>
+                    </h4>
                     <div class="fostered-dates d-flex flex-column text-start">
                       <div class="badge mb-2 <%= status_classes(fostered_pet.status) %>">
                         <%= fostered_pet.status.to_s.titleize %>

--- a/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
+++ b/app/views/organizations/adopter_fosterer/fostered_pets/index.html.erb
@@ -17,14 +17,15 @@
                               style: "width: 100%; height: 100%; object-fit: cover;"
                             ) %>
                       </div>
+                    </div>
+                    <div class="d-flex flex-column align-items-center flex-shrink-0">
+                      <h2 class="card-title mb-0 flex-grow-1 text-center">
+                        <%= fostered_pet.pet.name %>
+                      </h2>
                       <div class="badge mt-2 <%= status_classes(fostered_pet.status) %>">
                         <%= fostered_pet.status.to_s.titleize %>
                       </div>
                     </div>
-
-                    <h3 class="card-title mb-0 flex-grow-1 text-center">
-                      <%= fostered_pet.pet.name %>
-                    </h3>
                     <div class="fostered-dates d-flex flex-column text-start">
                       <h5 class="mb-1">Start: <%= fostered_pet.start_date.strftime("%m/%d/%y") %></h5>
                       <h5 class="mt-1">End: <%= fostered_pet.end_date.strftime("%m/%d/%y") %></h5>

--- a/test/controllers/organizations/adopter_fosterer/fostered_pets_controller_test.rb
+++ b/test/controllers/organizations/adopter_fosterer/fostered_pets_controller_test.rb
@@ -30,17 +30,17 @@ module Organizations
             end
           end
 
-          should "return only current foster matches for the person" do
+          should "return current and upcoming foster matches for the person" do
             ActsAsTenant.with_tenant(@organization) do
               completed_foster = create(:pet, :completed_foster)
               current_foster = create(:pet, :current_foster, foster_person: @fosterer.person)
-              future_foster = create(:pet, :future_foster)
+              future_foster = create(:pet, :future_foster, foster_person: @fosterer.person)
 
               get adopter_fosterer_fostered_pets_url
 
               assert_includes assigns(:fostered_pets), current_foster.matches.first
+              assert_includes assigns(:fostered_pets), future_foster.matches.first
               assert_not_includes assigns(:fostered_pets), completed_foster.matches.first
-              assert_not_includes assigns(:fostered_pets), future_foster.matches.first
             end
           end
         end

--- a/test/factories/pets.rb
+++ b/test/factories/pets.rb
@@ -49,11 +49,16 @@ FactoryBot.define do
     end
 
     trait :future_foster do
+      transient do
+        foster_person { create(:person) }
+      end
+
       matches {
         start = Time.current + rand(1..3).months
         [association(:match,
           pet: instance,
           match_type: :foster,
+          person: foster_person,
           start_date: start,
           end_date: start + rand(3..6).months)]
       }


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/homeward-tails/issues/1231

# ✍️ Description
Fosterers can see a list of their current foster pets on the /fostered_pets index. However, it doesn't let fosterers view files or tasks of their upcoming fosters. 

This PR includes upcoming fosters in the query, and uses the badge from the staff fosters page. 

# 📷 Screenshots/Demos
I tried a few different placements for the badge, and I feel that the best options are below the photo and above the dates. 

Badge Below Photo: 

![Screenshot 2025-02-27 at 10 02 11 PM](https://github.com/user-attachments/assets/aa342676-6a27-4ea4-864c-644ded406118)

Badge Above Dates: 

![Screenshot 2025-02-27 at 10 05 42 PM](https://github.com/user-attachments/assets/2f65e306-dc26-4e14-9dbd-90225d225fbd)

I felt like the badge below the photo felt a little more evenly distributed, so that's what I have in the PR now. However, I'm happy to change it to the badge above the dates if that would be preferable. 

Interestingly, the difference between these two options is only visible on large pages - as the page gets increasingly smaller, both options result in the same orientations. 

![Screenshot 2025-02-27 at 10 04 38 PM](https://github.com/user-attachments/assets/25a9b2da-e1d0-4700-a8dc-2867d44a4dc3)

![Screenshot 2025-02-27 at 10 04 43 PM](https://github.com/user-attachments/assets/ea31e95d-0ab4-413c-bd2c-83656c42c315)

![Screenshot 2025-02-27 at 10 04 53 PM](https://github.com/user-attachments/assets/cf6a5507-7cb5-44e0-928e-66adb662238a)
