### PR TITLE
bug-fix: duplicating copy right year

### DIFF
--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -94,7 +94,7 @@
         <span>
           ©
           <span id="copyright">
-            <script>document.getElementById('copyright').appendChild(document.createTextNode(new Date().getFullYear()))</script>
+            <%= Time.now.year %>
           </span>
           <%= t('.rights') %>
         </span>

--- a/app/views/layouts/shared/_no_tenant_footer.html.erb
+++ b/app/views/layouts/shared/_no_tenant_footer.html.erb
@@ -20,7 +20,7 @@
              <!-- Desc -->
              <div class="col-md-6 col-12 text-center text-md-start">
                  <span>© <span id="copyright">
-                     <script>document.getElementById('copyright').appendChild(document.createTextNode(new Date().getFullYear()))</script>
+                     <%= Time.now.year %>
                  </span><%= t('.rights') %></span>
              </div>
                <!-- Links -->


### PR DESCRIPTION
Remove script and update with <%= Time.now.year %> to get current year for copyright.

# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/homeward-tails/issues/1367
# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

Remove script in partials where the copyright is. (layouts/shared/_footer and _no_tenant_footerand update) and update with <%= Time.now.year %> to get current year for copyright.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [(https://jam.dev/c/70877a41-a752-4986-a148-ea119a55e699)](https://jam.dev/c/70877a41-a752-4986-a148-ea119a55e699) is a great tool to help provide these in video or snapshot -->
[(https://jam.dev/c/70877a41-a752-4986-a148-ea119a55e699)](https://jam.dev/c/70877a41-a752-4986-a148-ea119a55e699)
