### PR TITLE
1402 relocate google auth option

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,6 +17,8 @@
             <h1 class="mb-1 fw-bold">Sign up</h1>
           </div>
 
+          <%= render "devise/shared/google_oauth_button" %>
+
           <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
             <div class="form-group mb-3 bigger">
               <%= f.email_field :email,

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -19,6 +19,8 @@
             <span>Don’t have an account? <%= link_to "Sign up", new_user_registration_path, class: 'small fw-bold' %></span>
           </div>
 
+          <%= render "devise/shared/google_oauth_button" %>
+
           <div>
             <% if flash[:alert] %>
               <div class="alert alert-danger" role="alert">
@@ -45,23 +47,6 @@
                 <%= f.submit "Log in", class: 'btn btn-primary' %>
                
               </div>
-            </div>
-
-            <div class="d-grid gap-3 mb-4">
-              <div class="position-relative mt-4">
-                <hr class="bg-gray-300">
-                <p class="position-absolute top-50 start-50 translate-middle bg-white px-3 text-muted small">
-                  or
-                </p>
-              </div>
-              <%= link_to user_google_oauth2_omniauth_authorize_path, 
-                method: :post, 
-                data: { turbo: 'false' },
-                class: "btn border w-100 d-flex align-items-center justify-content-center gap-2",
-                onclick: "this.innerHTML='<span class=\"spinner-border spinner-border-sm me-2\" role=\"status\" aria-hidden=\"true\"></span>Signing in...'" do %>
-                <%= image_tag "google.svg", size: "20x20", alt: "Google" %>
-                Continue with Google
-              <% end %>
             </div>
           <% end %>
         </div>

--- a/app/views/devise/shared/_google_oauth_button.html.erb
+++ b/app/views/devise/shared/_google_oauth_button.html.erb
@@ -1,0 +1,21 @@
+<%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <div class="d-grid gap-1 mb-1">
+        <%= link_to user_google_oauth2_omniauth_authorize_path, 
+          method: :post, 
+          data: { turbo: 'false' },
+          class: "btn border w-100 d-flex align-items-center justify-content-center gap-2",
+          onclick: "this.innerHTML='<span class=\"spinner-border spinner-border-sm me-2\" role=\"status\" aria-hidden=\"true\"></span>Signing in...'" do %>
+          <%= image_tag "google.svg", size: "20x20", alt: "Google" %>
+          Continue with Google
+        <% end %>
+        <div class="position-relative mt-4">
+          <hr class="bg-gray-300">
+            <p class="position-absolute top-50 start-50 translate-middle bg-white px-3 text-muted small">
+              or
+            </p>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -17,24 +17,3 @@
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %>
 <% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <div class="d-grid gap-3 mb-4">
-      <div class="position-relative mt-4">
-        <hr class="bg-gray-300">
-        <p class="position-absolute top-50 start-50 translate-middle bg-white px-3 text-muted small">
-          or 
-        </p>
-      </div>
-      <%= link_to user_google_oauth2_omniauth_authorize_path, 
-        method: :post, 
-        data: { turbo: 'false' },
-        class: "btn border w-100 d-flex align-items-center justify-content-center gap-2",
-        onclick: "this.innerHTML='<span class=\"spinner-border spinner-border-sm me-2\" role=\"status\" aria-hidden=\"true\"></span>Signing in...'" do %>
-        <%= image_tag "google.svg", size: "20x20", alt: "Google" %>
-        Continue with Google
-      <% end %>
-    </div>
-  <% end %>
-<% end %>


### PR DESCRIPTION
# 🔗 Issue
#1402

# ✍️ Description
- Moves the Google Auth button in both "app/views/devise/sessions/new.html.erb" and "app/views/devise/registrations/new.html.erb" under the Log in and Sign Up headers

- Move hortizontal rule and "or" divider under Google Auth Button

- removes Google Auth button from devise shared links partial ("app/views/devise/shared/_links.html.erb")


# 📷 Screenshots/Demos

<h3> Before </h3>

![Screenshot 2025-04-10 at 10 35 44 PM](https://github.com/user-attachments/assets/a6922d95-110d-4a7e-a668-2b177297b393)
![Screenshot 2025-04-10 at 10 35 54 PM](https://github.com/user-attachments/assets/1da20657-57f9-4061-82e2-83e26fe2ec27)

<h3> After </h3>

![Screenshot 2025-04-10 at 11 17 03 PM](https://github.com/user-attachments/assets/d4efc5af-9c48-4967-849d-b7ca0f39b1f7)
![Screenshot 2025-04-10 at 11 16 47 PM](https://github.com/user-attachments/assets/612a4433-7c73-4c8c-92c9-7a1b3eaee0fe)
