### PR TITLE
Fix: Last modified details to be shown when new note is created in Adopter Application and Fosterer

### DIFF
--- a/app/views/organizations/staff/shared/_notes.html.erb
+++ b/app/views/organizations/staff/shared/_notes.html.erb
@@ -39,13 +39,11 @@
           <%= form.hidden_field :notable_type, value: notable.class.name %>
           <%= form.hidden_field :context, value: context %>        
           <div class="d-flex align-items-center justify-content-between mt-2">
-            <% if notable.note&.persisted? %>
-              <div class="text-muted small notes-last-modified-<%= notable.id %>">
+            <div class="text-muted small notes-last-modified-<%= notable.id %>">
+              <% if notable.note&.persisted? %> 
                 Last modified: <%= notable.note.updated_at.strftime("#{notable.note.updated_at.day.ordinalize} %B, %Y") %>
-              </div>
-            <% else %>
-              <div></div>
-            <% end %>
+              <% end %>
+            </div>
             <%= form.submit t("general.save"), 
                   class: "btn btn-primary position-relative" ,
                   data: { bs_dismiss: "modal" } %>


### PR DESCRIPTION
# 🔗 Issue
#1424

# ✍️ Description
- Have fixed issue wherein last modified details was not getting displayed when new note was created. Issue was due to unavailability of class which was getting updated to display those details when note was created.

# 📷 Screenshots/Demos

[Alta Pet Rescue _ Homeward Tails.webm](https://github.com/user-attachments/assets/cadbd162-3eb2-47ed-89ca-4599a68eff94)

