### PR TITLE
Fix: Show Navbar when sign up validation error occurs

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,12 +14,13 @@ class RegistrationsController < Devise::RegistrationsController
   # MARK: only adopters are created through this route.
   def create
     super do |resource|
-      # TODO: Currently a person shouldn't exist without a user with the same email. If the person exists (but no user),
-      # how should we be handling this newly created user?
-      if resource.persisted? && !Person.exists?(email: resource.email)
-        person = Person.create!(user_id: resource.id, first_name: resource.first_name, last_name: resource.last_name,
-          email: resource.email)
-        person.add_group(:adopter)
+      if resource.persisted?
+        # TODO: Currently a person shouldn't exist without a user with the same email. If the person exists (but no user),
+        # how should we be handling this newly created user?
+        unless Person.exists?(email: resource.email)
+          person = Person.create!(user_id: resource.id, first_name: resource.first_name, last_name: resource.last_name, email: resource.email)
+          person.add_group(:adopter)
+        end
       end
     end
   end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -18,7 +18,7 @@ class RegistrationsController < Devise::RegistrationsController
       # how should we be handling this newly created user?
       if resource.persisted? && !Person.exists?(email: resource.email)
         person = Person.create!(user_id: resource.id, first_name: resource.first_name, last_name: resource.last_name,
-                                email: resource.email)
+          email: resource.email)
         person.add_group(:adopter)
       end
     end
@@ -26,7 +26,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   def update_resource(resource, params)
     if resource.google_oauth_user?
-      params.delete('current_password')
+      params.delete("current_password")
       resource.update_without_password(params)
     else
       resource.update_with_password(params)
@@ -37,35 +37,35 @@ class RegistrationsController < Devise::RegistrationsController
 
   def set_layout
     if allowed_to?(:index?, with: Organizations::DashboardPolicy)
-      'dashboard'
+      "dashboard"
     elsif allowed_to?(:index?, with: Organizations::AdopterFosterDashboardPolicy)
-      'adopter_foster_dashboard'
+      "adopter_foster_dashboard"
     else
-      'application'
+      "application"
     end
   end
 
   def sign_up_params
     params.require(:user).permit(:username,
-                                 :first_name,
-                                 :last_name,
-                                 :email,
-                                 :password,
-                                 :signup_role,
-                                 :tos_agreement,
-                                 adopter_foster_account_attributes: [:user_id])
+      :first_name,
+      :last_name,
+      :email,
+      :password,
+      :signup_role,
+      :tos_agreement,
+      adopter_foster_account_attributes: [:user_id])
   end
 
   def account_update_params
     params.require(:user).permit(:username,
-                                 :first_name,
-                                 :last_name,
-                                 :email,
-                                 :password,
-                                 :password_confirmation,
-                                 :signup_role,
-                                 :current_password,
-                                 :avatar)
+      :first_name,
+      :last_name,
+      :email,
+      :password,
+      :password_confirmation,
+      :signup_role,
+      :current_password,
+      :avatar)
   end
 
   def after_update_path_for(_resource)


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
[Fix: Nav bar is removed when sign-up validation errors occur](https://github.com/rubyforgood/homeward-tails/issues/1423)

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
When a user signs up and a validation error occurs, the navbar remains visible

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

https://github.com/user-attachments/assets/a78c73a4-e3b5-4a53-b223-dc2e7ea9b2ea

