### PR TITLE
migrate to azure-blob gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,8 +68,8 @@ gem "dartsass-rails"
 # Active storage validations
 gem "active_storage_validations"
 
-# Use Azure Blob Storage for Active Storage
-gem "azure-storage-blob", "~> 2.0", require: false
+# Use Azure Blob for Active Storage
+gem "azure-blob", require: false
 
 # validate adopter phone numbers
 gem "phonelib"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,14 +89,8 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     annotaterb (4.15.0)
     ast (2.4.3)
-    azure-storage-blob (2.0.3)
-      azure-storage-common (~> 2.0)
-      nokogiri (~> 1, >= 1.10.8)
-    azure-storage-common (2.0.4)
-      faraday (~> 1.0)
-      faraday_middleware (~> 1.0, >= 1.0.0.rc1)
-      net-http-persistent (~> 4.0)
-      nokogiri (~> 1, >= 1.10.8)
+    azure-blob (0.5.9)
+      rexml
     base64 (0.3.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
@@ -218,8 +212,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
     ferrum (0.17.1)
       addressable (~> 2.5)
       base64 (~> 0.2)
@@ -352,8 +344,6 @@ GEM
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
     nenv (0.3.0)
-    net-http-persistent (4.0.5)
-      connection_pool (~> 2.2)
     net-imap (0.5.8)
       date
       net-protocol
@@ -654,7 +644,7 @@ DEPENDENCIES
   active_storage_validations
   acts_as_tenant
   annotaterb
-  azure-storage-blob (~> 2.0)
+  azure-blob
   better_errors (~> 2.9, >= 2.9.1)
   bootsnap
   bootstrap

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -16,7 +16,7 @@ local:
 #   bucket: baja-pet-rescue-dogs
 
 azure:
-  service: AzureStorage
+  service: AzureBlob
   storage_account_name: <%= Rails.application.credentials.dig(:azure, :storage_account_name) %>
   storage_access_key: <%= Rails.application.credentials.dig(:azure, :storage_access_key) %>
   container: <%= Rails.application.credentials.dig(:azure, :container) %>


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
 `ActiveStorage::Service::AzureStorageService` is deprecated and will be removed in Rails 8.1

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This migrates from Azure-Storage-Blob to Azure-Blob

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
