### PR TITLE
Production db backup to local

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.3.0
-postgres 12.12
+ruby     3.3.0
+postgres 16

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby     3.3.0
+ruby 3.3.0
 postgres 16

--- a/lib/tasks/production_db.rake
+++ b/lib/tasks/production_db.rake
@@ -1,0 +1,117 @@
+# To connect to the Azure postgres database, the IP address of machine you are connecting with must be whitelisted
+#
+# Go to the Azure dashboard and open the homewardtails-db resource
+# Settings > Networking > Firewall rules
+# Click "Add current client IP address" or enter manually
+
+namespace :db do
+  desc "Back up the production DB to local /tmp folder"
+  task :backup_production_to_local do
+    current_time = Time.current.strftime("%Y%m%d%H%M%S")
+    backup_filename = "/tmp/#{current_time}.dump"
+
+    db_host = production_credentials(:deploy, :db_host)
+    db_user = production_credentials(:deploy, :database_username)
+    db_pass = production_credentials(:deploy, :database_password)
+
+    ENV["PGPASSWORD"] = db_pass
+
+    puts "Running pg_dump to #{backup_filename}..."
+    system("pg_dump -Fc -v --host=#{db_host} --username=#{db_user} --dbname=postgres -f #{backup_filename}")
+
+    if $?.success?
+      puts "Backup successful: #{backup_filename}"
+    else
+      puts "Backup failed."
+    end
+  end
+
+  desc "Restore latest production backup to local development database"
+  PASSWORD_REPLACEMENT = "123456"
+
+  task restore_production_to_local: :environment do
+    if ENV["RAILS_ENV"] == "production"
+      raise "You may not run this backup script in production!"
+    end
+
+    dump_file = Dir["/tmp/*.dump"].sort.last
+
+    unless dump_file && File.exist?(dump_file)
+      puts "No backup file found in /tmp"
+      exit 1
+    end
+
+    puts "Restoring backup from #{dump_file}..."
+
+    # Load local DB config
+    config = Rails.configuration.database_configuration["development"]["primary"]
+    db_name = config["database"]
+    db_host = config["host"] || "localhost"
+    db_username = config["username"]
+    db_password = config["password"]
+
+    puts "Dropping and recreating local database..."
+    system("bin/rails db:drop")
+    system("bin/rails db:create")
+    system("bin/rails db:schema:load")
+
+    toc_list = filter_dump_file(dump_file)
+
+    puts "Restoring with pg_restore..."
+    system("PGPASSWORD='#{db_password}' pg_restore --clean --no-acl --no-owner -L #{toc_list} -h #{db_host} -d #{db_name} -U #{db_username} #{dump_file}")
+
+    if $?.success?
+      puts "Database restored successfully."
+    else
+      puts "Database restore failed."
+    end
+
+    # Update the ar_internal_metadata table to have the correct environment
+    # This is needed because attempting to drop the development DB will
+    # raise a protected environment error.
+    system("bin/rails db:environment:set RAILS_ENV=development")
+
+    puts "Replacing all the passwords with the replacement for ease of use: '#{PASSWORD_REPLACEMENT}'"
+    # system("bin/rails db:replace_user_passwords")
+    replace_user_passwords
+  end
+end
+
+private
+
+def production_credentials(*keys)
+  @production_credentials ||= ActiveSupport::EncryptedConfiguration.new(
+    config_path: Rails.root.join("config", "credentials", "production.yml.enc"),
+    key_path: Rails.root.join("config", "credentials", "production.key"),
+    env_key: "RAILS_MASTER_KEY",
+    raise_if_missing_key: true
+  )
+
+  keys.reduce(@production_credentials) { |hash, key| hash[key] }
+end
+
+def filter_dump_file(dump_file)
+  toc_list = "/tmp/restore.list"
+
+  puts "Filtering out Azure-related extensions and cron schema objects from the dump..."
+  system("pg_restore -l #{dump_file} > #{toc_list}") || exit(1)
+
+  filtered_lines = File.readlines(toc_list).reject do |line|
+    line.match?(/cron/i) ||
+      line.match?(/EXTENSION.*(pg_cron|azure|pgaadauth)/i)
+  end
+
+  File.write(toc_list, filtered_lines.join)
+  toc_list
+end
+
+def replace_user_passwords
+  # Generate the encrypted password so that we can quickly update
+  # all users with `update_all`
+
+  u = User.new(password: PASSWORD_REPLACEMENT)
+  u.save
+  encrypted_password = u.encrypted_password
+
+  User.all.update_all(encrypted_password: encrypted_password)
+end

--- a/lib/tasks/production_db.rake
+++ b/lib/tasks/production_db.rake
@@ -36,7 +36,7 @@ namespace :db do
 
     dump_file = Dir["/tmp/*.dump"].sort.last
 
-    unless dump_file && File.exist?(dump_file)
+    unless File.exist?(dump_file)
       puts "No backup file found in /tmp"
       exit 1
     end

--- a/lib/tasks/production_db.rake
+++ b/lib/tasks/production_db.rake
@@ -4,6 +4,8 @@
 # Settings > Networking > Firewall rules
 # Click "Add current client IP address" or enter manually
 
+PASSWORD_REPLACEMENT = "123456"
+
 namespace :db do
   desc "Back up the production DB to local /tmp folder"
   task :backup_production_to_local do
@@ -27,14 +29,13 @@ namespace :db do
   end
 
   desc "Restore latest production backup to local development database"
-  PASSWORD_REPLACEMENT = "123456"
 
   task restore_production_to_local: :environment do
     if ENV["RAILS_ENV"] == "production"
       raise "You may not run this backup script in production!"
     end
 
-    dump_file = Dir["/tmp/*.dump"].sort.last
+    dump_file = Dir["/tmp/*.dump"].max
 
     unless File.exist?(dump_file)
       puts "No backup file found in /tmp"


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This allows backing up the production database to your local machine and restoring it to the dev db. I have not tested this using docker.

 This could be altered easily in the future to create the backup and store it in an azure blob. [Reference human-essentials bakup](https://github.com/rubyforgood/human-essentials/blob/main/lib/tasks/backup_db.rake) and [restore](https://github.com/rubyforgood/human-essentials/blob/main/lib/tasks/fetch_latest_db.rake). We currently rely on Azures built in db backup but I do not believe that we can access the actual dump file. Creating a backup blob would be an alternate/additional method. Something to discuss in the future.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
