### PR TITLE
#1465 add powered by homeward tails links

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -9,7 +9,10 @@
             <div class='d-flex justify-content-center'>
               <div class='d-flex flex-column align-items-center mb-3'>
                 <% if Current.organization.avatar.attached? %>
-                  <%= image_tag Current.organization.avatar, alt: current_organization_name, title: current_organization_name, height: 75 %>
+                  <%= image_tag Current.organization.avatar,
+                  alt: current_organization_name,
+                  title: current_organization_name,
+                  height: 75 %>
                 <% end %>
                 <h1><%= Current.tenant.name %></h1>
               </div>
@@ -22,44 +25,65 @@
           <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
             <div class="form-group mb-3 bigger">
               <%= f.email_field :email,
-                                autofocus: true,
-                                required: true,
-                                autocomplete: "email", class: 'form-control' %>
+                            autofocus: true,
+                            required: true,
+                            autocomplete: "email",
+                            class: "form-control" %>
             </div>
 
             <div class="form-group mb-3 bigger">
-              <%= f.text_field :first_name, required: true, class: 'form-control' %>
+              <%= f.text_field :first_name, required: true, class: "form-control" %>
             </div>
 
             <div class="form-group mb-3 bigger">
-              <%= f.text_field :last_name, required: true, class: 'form-control' %>
+              <%= f.text_field :last_name, required: true, class: "form-control" %>
             </div>
 
             <div class="form-group mb-3 bigger">
               <%= f.password_field :password,
-                                  required: true,
-                                  autocomplete: "new-password",
-                                  class: 'form-control' %>
+                               required: true,
+                               autocomplete: "new-password",
+                               class: "form-control" %>
               <% if @minimum_password_length %>
-                <em>(<%= @minimum_password_length %> characters minimum)</em>
-              <% end %><br />
+                <em>(<%= @minimum_password_length %>
+                  characters minimum)</em>
+              <% end %><br/>
             </div>
 
             <%= f.check_box :tos_agreement, required: true do %>
-              <span>I agree to the </span>
-              <%= link_to 'Terms and Conditions', terms_and_conditions_path,
-                          target: '_blank', class: 'text-decoration-none' %>
-              <span>& </span>
-              <%= link_to 'Privacy Policy', privacy_policy_path,
-                          target: '_blank', class: 'text-decoration-none' %>
+              <span>I agree to the
+              </span>
+              <%= link_to "Terms and Conditions",
+              terms_and_conditions_path,
+              target: "_blank",
+              class: "text-decoration-none" %>
+              <span>&
+              </span>
+              <%= link_to "Privacy Policy",
+              privacy_policy_path,
+              target: "_blank",
+              class: "text-decoration-none" %>
             <% end %>
 
             <div class="actions">
-              <%= f.submit "Create Account", class: 'btn btn-outline-dark mb-3 bigger',
-                          data: { turbo: false } %>
+              <%= f.submit "Create Account",
+                       class: "btn btn-outline-dark mb-3 bigger",
+                       data: {
+                         turbo: false,
+                       } %>
             </div>
             <%= render "devise/shared/links" %>
           <% end %>
+
+          <div class="mt-2 d-flex justify-content-end align-items-end gap-1 ">
+            <div class="fst-italic text-black pb-2">Powered By</div>
+            <%= link_to "/", target: "_blank", class: 'btn btn-outline-primary border-0' do %>
+              <div class="fs-3">
+                <%= t("root.index.title") %>
+              </div>
+              <div class="fw-light text-secondary"><%= t("root.index.sub_title") %></div>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -74,9 +74,9 @@
             </div>
             <%= render "devise/shared/links" %>
           <% end %>
-          <div class="mt-2 d-flex justify-content-end align-items-end gap-3 ">
+          <div class="mt-2 d-flex justify-content-end align-items-end gap-3">
             <div class="fst-italic text-black">Powered By</div>
-            <%= link_to "/", target: "_blank", class: 'link-primary link-opacity-25-hover border-0' do %>
+            <%= link_to "/", target: "_blank", class: "link-primary link-opacity-25-hover"  do %>
               <div class="fs-3">
                 <%= t("root.index.title") %>
               </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -74,14 +74,13 @@
             </div>
             <%= render "devise/shared/links" %>
           <% end %>
-
-          <div class="mt-2 d-flex justify-content-end align-items-end gap-1 ">
-            <div class="fst-italic text-black pb-2">Powered By</div>
-            <%= link_to "/", target: "_blank", class: 'btn btn-outline-primary border-0' do %>
+          <div class="mt-2 d-flex justify-content-end align-items-end gap-3 ">
+            <div class="fst-italic text-black">Powered By</div>
+            <%= link_to "/", target: "_blank", class: 'link-primary link-opacity-25-hover border-0' do %>
               <div class="fs-3">
                 <%= t("root.index.title") %>
               </div>
-              <div class="fw-light text-secondary"><%= t("root.index.sub_title") %></div>
+              <div class="fw-light"><%= t("root.index.sub_title") %></div>
             <% end %>
           </div>
         </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -59,14 +59,13 @@
               </div>
             </div>
           <% end %>
-
-          <div class="mt-2 d-flex justify-content-end align-items-end gap-1 ">
-            <div class="fst-italic text-black pb-2">Powered By</div>
-            <%= link_to "/", target: "_blank", class: 'btn btn-outline-primary border-0' do %>
+          <div class="mt-5 d-flex justify-content-end align-items-end gap-3 ">
+            <div class="fst-italic text-black">Powered By</div>
+            <%= link_to "/", target: "_blank", class: 'link-primary link-opacity-25-hover border-0' do %>
               <div class="fs-3">
                 <%= t("root.index.title") %>
               </div>
-              <div class="fw-light text-secondary"><%= t("root.index.sub_title") %></div>
+              <div class="fw-light"><%= t("root.index.sub_title") %></div>
             <% end %>
           </div>
         </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,13 +10,17 @@
             <div class='d-flex justify-content-center'>
               <div class='d-flex flex-column align-items-center mb-3'>
                 <% if Current.organization.avatar.attached? %>
-                  <%= image_tag Current.organization.avatar, alt: current_organization_name, title: current_organization_name, height: 75 %>
+                  <%= image_tag Current.organization.avatar,
+                  alt: current_organization_name,
+                  title: current_organization_name,
+                  height: 75 %>
                 <% end %>
                 <h1><%= Current.tenant.name %></h1>
               </div>
             </div>
             <h1 class="mb-1 fw-bold">Log in</h1>
-            <span>Don’t have an account? <%= link_to "Sign up", new_user_registration_path, class: 'small fw-bold' %></span>
+            <span>Don’t have an account?
+              <%= link_to "Sign up", new_user_registration_path, class: "small fw-bold" %></span>
           </div>
 
           <%= render "devise/shared/google_oauth_button" %>
@@ -26,29 +30,45 @@
               <div class="alert alert-danger" role="alert">
                 <%= alert %>
               </div>
-            <% end%>
+            <% end %>
           </div>
           <%= bootstrap_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control' %>
+            <%= f.email_field :email,
+                          autofocus: true,
+                          autocomplete: "email",
+                          class: "form-control" %>
 
-            <%= f.password_field :password, autocomplete: "current-password", class: 'form-control' %>
-
+            <%= f.password_field :password,
+                             autocomplete: "current-password",
+                             class: "form-control" %>
             <!-- Checkbox -->
             <div class="d-lg-flex justify-content-between align-items-center mb-4">
               <div>
                 <%= f.check_box :remember_me %>
               </div>
               <div>
-                <%= link_to "Forgot your password?", new_password_path(resource_name), class: 'small text-end' %>
+                <%= link_to "Forgot your password?",
+                new_password_path(resource_name),
+                class: "small text-end" %>
               </div>
             </div>
             <div class='mb-1'>
               <div class="d-grid">
-                <%= f.submit "Log in", class: 'btn btn-primary' %>
-               
+                <%= f.submit "Log in", class: "btn btn-primary" %>
+
               </div>
             </div>
           <% end %>
+
+          <div class="mt-2 d-flex justify-content-end align-items-end gap-1 ">
+            <div class="fst-italic text-black pb-2">Powered By</div>
+            <%= link_to "/", target: "_blank", class: 'btn btn-outline-primary border-0' do %>
+              <div class="fs-3">
+                <%= t("root.index.title") %>
+              </div>
+              <div class="fw-light text-secondary"><%= t("root.index.sub_title") %></div>
+            <% end %>
+          </div>
         </div>
       </div>
     </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -59,9 +59,9 @@
               </div>
             </div>
           <% end %>
-          <div class="mt-5 d-flex justify-content-end align-items-end gap-3 ">
+          <div class="mt-5 d-flex justify-content-end align-items-end gap-3">
             <div class="fst-italic text-black">Powered By</div>
-            <%= link_to "/", target: "_blank", class: 'link-primary link-opacity-25-hover border-0' do %>
+            <%= link_to "/", target: "_blank", class: "link-primary link-opacity-25-hover" do %>
               <div class="fs-3">
                 <%= t("root.index.title") %>
               </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -114,6 +114,7 @@ en:
   root:
     index:
       title: "Homeward Tails"
+      sub_title: "A Ruby For Good project"
       about: "About"
       partners: "Partners"
       pet: "Pets"


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
Resolves #1465 

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Adds powered by Homeward Tails links on sign_in/sign_up pages. Link opens global root page in a new tab.

I think having the link at the bottom of the card is unobtrusive and keeps the top of the form clean. Open to suggestions on styling/placement.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

[Screencast from 2025-06-27 20-25-04.webm](https://github.com/user-attachments/assets/8f117a68-dc7e-47ed-bcf0-5f3113e0f5b7)


