### PR TITLE
#1468 custom page links

### DIFF
--- a/app/controllers/organizations/staff/custom_pages_controller.rb
+++ b/app/controllers/organizations/staff/custom_pages_controller.rb
@@ -3,6 +3,8 @@ module Organizations
     class CustomPagesController < Organizations::BaseController
       layout "dashboard"
       before_action :set_custom_page, only: %i[edit update]
+      before_action :example_pet, only: %i[edit]
+
       def edit
       end
 
@@ -23,6 +25,10 @@ module Organizations
       def set_custom_page
         @custom_page = CustomPage.first
         authorize! @custom_page
+      end
+
+      def example_pet
+        @example_pet ||= Pet.first
       end
     end
   end

--- a/app/controllers/organizations/staff/custom_pages_controller.rb
+++ b/app/controllers/organizations/staff/custom_pages_controller.rb
@@ -28,7 +28,7 @@ module Organizations
       end
 
       def example_pet
-        @example_pet ||= Pet.first
+        @example_pet ||= Pet.unadopted.first
       end
     end
   end

--- a/app/views/organizations/home/index.html.erb
+++ b/app/views/organizations/home/index.html.erb
@@ -1,17 +1,26 @@
 <section id="hero">
-  <div class="bg-image" style="background-image: url('<%= Current.organization.custom_page&.hero_image&.attached? ? url_for(Current.organization.custom_page.hero_image) : asset_path('dog-run.png') %>'); background-position: center; background-size: cover;">
-    <div class="mask py-lg-16 py-5" style="background-color: rgba(255, 255, 255, 0.8);">
+  <div
+    class="bg-image"
+    style="background-image: url('<%= Current.organization.custom_page&.hero_image&.attached? ? url_for(Current.organization.custom_page.hero_image) : asset_path('dog-run.png') %>'); background-position: center; background-size: cover;"
+  >
+    <div
+      class="mask py-lg-16 py-5"
+      style="background-color: rgba(255, 255, 255, 0.8);"
+    >
       <div class="container">
         <div class="d-flex row justify-content-center align-items-center">
           <div class="d-flex justify-content-center">
             <h1 class="display-2 fw-bold mb-1 text-primary "><%= Current.organization.name %></h1>
           </div>
           <div class="d-flex justify-content-center">
-            <p class="lead mb-4 text-black"><%= Current.organization.custom_page&.hero || t('.every_paw') %></p>
+            <p class="lead mb-4 text-black"><%= Current.organization.custom_page&.hero || t(".every_paw") %></p>
           </div>
           <div class="d-flex justify-content-center">
             <% if user_signed_in? %>
-              <%= render partial: "organizations/shared/unique_species", locals: { adoptable_unique_species: @adoptable_unique_species } %>
+              <%= render partial: "organizations/shared/unique_species",
+              locals: {
+                adoptable_unique_species: @adoptable_unique_species,
+              } %>
             <% else %>
               <%= link_to t("general.become_an_adopter"),
               new_user_registration_path,
@@ -23,32 +32,51 @@
     </div>
   </div>
 </section>
-
 <!--//? ADOPTION -->
 <section class="pt-5 pb-5" id="adopt">
   <div class="container mb-md-5 mt-md-5 d-flex flex-column align-items-center">
-
     <!--//? section heading -->
     <div class="mb-5">
       <h2 class="section-heading text-uppercase text-xl">
-        <%= t('.adopt')%>
+        <%= t(".adopt") %>
       </h2>
     </div>
     <!--//? bootstrap cards -->
-    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 mt-4 w-100 justify-content-center">
+    <div
+      class="
+        row row-cols-1 row-cols-md-2 row-cols-lg-4 mt-4 w-100 justify-content-center
+      "
+    >
       <% @pets.each do |pet| %>
         <%= link_to adoptable_pet_path(pet) do %>
           <div class="col">
             <div class="card featured-pets h-100 mt-4 mt-lg-0">
-              <%= image_tag(pet.images.first, alt: pet.name, height: 275, style: "object-fit: cover;") %>
+              <%= image_tag(
+                pet.images.first,
+                alt: pet.name,
+                height: 275,
+                style: "object-fit: cover;",
+              ) %>
               <div class="card-img-overlay p-0"></div>
               <div class="card-footer">
                 <p class="card-text text-black">
-                  <%= t('.adopt')%> <%= pet.name %>
+                  <%= t(".adopt") %>
+                  <%= pet.name %>
                 </p>
-                <svg xmlns="http://www.w3.org/2000/svg" height="22" width="22" viewBox="0 0 448 512">
-                  <!--!Font Awesome Free 6.5.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
-                  <path fill="#5E3FCB" d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"/>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  height="22"
+                  width="22"
+                  viewBox="0 0 448 512"
+                >
+                  <!--!Font Awesome Free 6.5.1 by @fontawesome -
+                  https://fontawesome.com License -
+                  https://fontawesome.com/license/free Copyright 2024
+                  Fonticons, Inc.-->
+                  <path
+                    fill="#5E3FCB"
+                    d="M438.6 278.6c12.5-12.5 12.5-32.8 0-45.3l-160-160c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3L338.8 224 32 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l306.7 0L233.4 393.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0l160-160z"
+                  />
                 </svg>
               </div>
             </div>
@@ -58,60 +86,79 @@
     </div>
   </div>
 </section>
-
 <!--//? how to apply section ?//-->
 <section class="pt-5 pb-5" id="how-to-apply">
   <div class="container mb-md-5 mt-md-5">
     <!--//? section header -->
     <div class="text-center mb-5">
       <h2 class="section-heading text-uppercase text-xl">
-        <%= t('.how_to_apply') %>
+        <%= t(".how_to_apply") %>
       </h2>
     </div>
-    <!--//? cards section - info (not bootstrap card)  -->
-    <div class="row justify-content-center text-center row-cols-1 row-cols-md-2 row-cols-lg-4 mt-4">
+    <!--//? cards section - info (not bootstrap card) -->
+    <div
+      class="
+        row justify-content-center text-center row-cols-1 row-cols-md-2 row-cols-lg-4
+        mt-4
+      "
+    >
       <div class="col">
         <div class="h-100 mt-4 mt-lg-0">
-          <%= image_tag('paw-account.svg', class: 'w-50 px-4 px-lg-0',
-          style: "object-fit: cover;", alt: "Create an account") %>
+          <%= image_tag(
+            "paw-account.svg",
+            class: "w-50 px-4 px-lg-0",
+            style: "object-fit: cover;",
+            alt: "Create an account",
+          ) %>
           <p class="card-text text-black fs-5 mt-2">
-            <%= t('.create_account') %>
+            <%= t(".create_account") %>
           </p>
         </div>
       </div>
       <div class="col">
         <div class="h-100 mt-4 mt-lg-0">
-          <%= image_tag('paw-profile.svg', class: 'w-50 px-4 px-lg-0',
-          style: "object-fit: cover;", alt: "Complete questionnaire") %>
+          <%= image_tag(
+            "paw-profile.svg",
+            class: "w-50 px-4 px-lg-0",
+            style: "object-fit: cover;",
+            alt: "Complete questionnaire",
+          ) %>
           <p class="card-text text-black fs-5 mt-2">
-            <%= t('.complete_questionaire') %>
+            <%= t(".complete_questionaire") %>
           </p>
         </div>
       </div>
       <div class="col">
         <div class="h-100 mt-4 mt-lg-0">
-          <%= image_tag('paw-account.svg', class: 'w-50 px-4 px-lg-0',
-          style: "object-fit: cover;", alt: "Browse pets") %>
+          <%= image_tag(
+            "paw-account.svg",
+            class: "w-50 px-4 px-lg-0",
+            style: "object-fit: cover;",
+            alt: "Browse pets",
+          ) %>
           <p class="card-text text-black fs-5 mt-2">
-            <%= t('.browse_pets') %>
+            <%= t(".browse_pets") %>
           </p>
         </div>
       </div>
       <div class="col">
         <div class="h-100 mt-4 mt-lg-0">
-          <%= image_tag('paw-account.svg', class: 'w-50 px-4 px-lg-0',
-          style: "object-fit: cover;", alt: "Click apply") %>
+          <%= image_tag(
+            "paw-account.svg",
+            class: "w-50 px-4 px-lg-0",
+            style: "object-fit: cover;",
+            alt: "Click apply",
+          ) %>
           <p class="card-text text-black fs-5 mt-2">
-            <%= t('.click_apply') %>
+            <%= t(".click_apply") %>
           </p>
         </div>
       </div>
     </div>
   </div>
 </section>
-
-
 <!-- ABOUT US-->
+<%= tag.a name: "about_us" %>
 <section class="bg-light pt-5 pb-5" id="about_us">
   <div class="container mb-md-5 mt-md-5">
     <div class="text-center mb-5">
@@ -123,33 +170,50 @@
       <div class="col-lg-4 col-md-6 mb-4 mb-lg-0">
         <span class="ratio ratio-1x1 w-100 border border-0">
           <% if Current.organization.custom_page.about_us_images.attached? && Current.organization.custom_page.about_us_images.count > 0 %>
-            <%= image_tag(Current.organization.custom_page.about_us_images.first,
-          class: 'rounded-5 w-100 px-4 px-lg-0', style: "object-fit: cover;") %>
+            <%= image_tag(
+              Current.organization.custom_page.about_us_images.first,
+              class: "rounded-5 w-100 px-4 px-lg-0",
+              style: "object-fit: cover;",
+            ) %>
           <% else %>
-            <%= image_tag('danielle_2.jpg', class: 'rounded-5 w-100 px-4 px-lg-0',
-          style: "object-fit: cover;") %>
+            <%= image_tag(
+              "danielle_2.jpg",
+              class: "rounded-5 w-100 px-4 px-lg-0",
+              style: "object-fit: cover;",
+            ) %>
           <% end %>
         </span>
       </div>
       <div class="col-lg-4 px-4 order-last order-lg-0">
         <p class='justify bigger'>
-          <%= simple_format(Current.organization.custom_page&.about) || "#{Current.organization.name} was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations." %>
+          <%= simple_format(Current.organization.custom_page&.about) ||
+            "#{Current.organization.name} was founded by an incredible group of ladies in April of 2020. Our initial goal was to have both a rescue and a spay/neuter clinic, however, we quickly realized that it would be more efficient to separate into two organizations." %>
         </p>
       </div>
       <div class="col-lg-4 col-md-6 d-none d-md-block mb-4 mb-lg-0">
         <span class="ratio ratio-1x1 w-100 border border-0">
           <% if Current.organization.custom_page.about_us_images.attached? && Current.organization.custom_page.about_us_images.count >= 2 %>
-            <%= image_tag(Current.organization.custom_page.about_us_images.second,
-          class: 'w-100 rounded-5 px-4 px-lg-0', style: "object-fit: cover;") %>
+            <%= image_tag(
+              Current.organization.custom_page.about_us_images.second,
+              class: "w-100 rounded-5 px-4 px-lg-0",
+              style: "object-fit: cover;",
+            ) %>
           <% else %>
 
-            <%= image_tag('danielle_3.jpg', class: 'rounded-5 px-4
-                          px-lg-0', style: "object-fit: cover;") %>
+            <%= image_tag(
+              "danielle_3.jpg",
+              class:
+                "rounded-5 px-4
+                                      px-lg-0",
+              style: "object-fit: cover;",
+            ) %>
           <% end %>
         </span>
       </div>
-    </div> <!--row-->
-  </div> <!--container-->
+    </div>
+    <!--row-->
+  </div>
+  <!--container-->
 </section>
 
 <% unless user_signed_in? %>
@@ -157,11 +221,9 @@
   <section class="pt-5 pb-5 bg-light" id="cta">
     <div class="container mb-md-5 mt-md-5">
       <div class="row text-center">
-        <div class="col-8 offset-2 border p-5 shadow-sm
-                    rounded bg-white">
-          <h3 class='mb-4'><%= t('.become_adopter_now') %></h3>
-          <%= link_to 'Sign Up', new_user_registration_path ,
-                      class: 'btn btn-primary' %>
+        <div class="col-8 offset-2 border p-5 shadow-sm rounded bg-white">
+          <h3 class='mb-4'><%= t(".become_adopter_now") %></h3>
+          <%= link_to "Sign Up", new_user_registration_path, class: "btn btn-primary" %>
         </div>
       </div>
     </div>

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -5,85 +5,83 @@
     </p>
   </div>
 
-  <%= form.fields_for :custom_page do |custom_page_form| %>
-    <div class="row mt-3">
-      <div class="col-lg-6">
-        <div class="form-group">
-          <%= form.text_field :hero,
-                          label: "Hero",
-                          autofocus: true,
-                          placeholder: "hero text",
-                          class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
-        </div>
-        <small class="form-text text-muted">
-          Image must be .png or .jpeg under 2MB
-        </small>
-        <div class="form-group mt-4">
-          <%= form.text_area :about,
-                         label: "About Us",
-                         placeholder: "About Us text",
-                         class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.file_field :about_us_images,
-                          multiple: true,
-                          accept: "image/png, image/jpeg",
-                          label: "About Us Images",
-                          class: "form-control" %>
-          <% @custom_page.about_us_images.each do |image| %>
-            <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
-          <% end %>
-          <small class="form-text text-muted">You can upload up to 2 images.
-            <br>
-            Images must be .png or .jpeg under 2MB
-          </small>
-        </div>
+  <div class="row mt-3">
+    <div class="col-lg-6">
+      <div class="form-group">
+        <%= form.text_field :hero,
+                        label: "Hero",
+                        autofocus: true,
+                        placeholder: "hero text",
+                        class: "form-control" %>
       </div>
-      <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
-        <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-          <%= image_tag(
-            "custom_page_hero.png",
-            class: "w-100",
-            style: "border: 3px solid #754FFE;",
-          ) %>
-          <%= image_tag("custom_page_adopt.png", class: "w-100") %>
-          <%= image_tag(
-            "custom_page_about_us.png",
-            class: "w-100",
-            style: "border: 3px solid #754FFE;",
-          ) %>
-        </div>
+      <div class="form-group">
+        <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
       </div>
-    </div>
-
-    <div class="row mt-5">
-      <h3 class="mb-1">Adoptable Pet Information</h3>
-      <div class="col-lg-6 form-group">
-        <%= form.text_area :adoptable_pet_info,
-                       label: "Information for adopters",
-                       placeholder: "Anything you would like adopters to know?",
+      <small class="form-text text-muted">
+        Image must be .png or .jpeg under 2MB
+      </small>
+      <div class="form-group mt-4">
+        <%= form.text_area :about,
+                       label: "About Us",
+                       placeholder: "About Us text",
                        class: "form-control" %>
       </div>
-      <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
-        <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-          <%= image_tag(
-            "custom_page_adoptable_pet.png",
-            class: "w-100",
-            style: "border: 3px solid #754FFE;",
-          ) %>
-        </div>
+      <div class="form-group">
+        <%= form.file_field :about_us_images,
+                        multiple: true,
+                        accept: "image/png, image/jpeg",
+                        label: "About Us Images",
+                        class: "form-control" %>
+        <% @custom_page.about_us_images.each do |image| %>
+          <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
+        <% end %>
+        <small class="form-text text-muted">You can upload up to 2 images.
+          <br>
+          Images must be .png or .jpeg under 2MB
+        </small>
       </div>
     </div>
+    <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
+      <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
+        <%= image_tag(
+          "custom_page_hero.png",
+          class: "w-100",
+          style: "border: 3px solid #754FFE;",
+        ) %>
+        <%= image_tag("custom_page_adopt.png", class: "w-100") %>
+        <%= image_tag(
+          "custom_page_about_us.png",
+          class: "w-100",
+          style: "border: 3px solid #754FFE;",
+        ) %>
+      </div>
+    </div>
+  </div>
 
-    <div class="row mt-3">
-      <div class="col-lg-12">
-        <%= form.submit "Save", class: "btn btn-primary" %>
-        <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
+  <div class="row mt-5">
+    <h3 class="mb-1">Adoptable Pet Information</h3>
+    <div class="col-lg-6 form-group">
+      <%= form.text_area :adoptable_pet_info,
+                     label: "Information for adopters",
+                     placeholder: "Anything you would like adopters to know?",
+                     class: "form-control" %>
+    </div>
+    <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
+      <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
+        <%= image_tag(
+          "custom_page_adoptable_pet.png",
+          class: "w-100",
+          style: "border: 3px solid #754FFE;",
+        ) %>
       </div>
     </div>
-  <% end %>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col-lg-12">
+      <%= form.submit "Save", class: "btn btn-primary" %>
+      <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
+    </div>
+  </div>
 
 <% end %>

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -1,76 +1,89 @@
 <%= bootstrap_form_with model: custom_page, :url => staff_custom_page_path(@custom_page), method: :patch do |form| %>
-  <div class='card-body'>
-    <div class="d-lg-flex align-items-center justify-content-between">
-      <h3 class="mb-1">Landing page details</h3>
-      <p class="text-muted mb-3" style="font-size: 12px;">Edit your landing page.
-      </p>
-    </div>
+  <div class="d-lg-flex align-items-center justify-content-between">
+    <h3 class="mb-1">Landing page details</h3>
+    <p class="text-muted mb-3" style="font-size: 12px;">Edit your landing page.
+    </p>
+  </div>
 
-    <%= form.fields_for :custom_page do |custom_page_form| %>
-      <div class="row mt-3">
-        <div class="col-lg-6">
-          <div class="form-group">
-            <%= form.text_field :hero,
-                                label: "Hero",
-                                autofocus: true,
-                                placeholder: "hero text",
-                                class: 'form-control' %>
-          </div>
-          <div class="form-group">
-            <%= form.file_field :hero_image,
-                                label: "Hero Image",
-                                class: 'form-control'%>
-          </div>
-          <small class="form-text text-muted"> Image must be .png or .jpeg under 2MB </small>
-          <div class="form-group mt-4">
-            <%= form.text_area :about, label: "About Us", placeholder: "About Us text", class: 'form-control' %>
-          </div>
-          <div class="form-group">
-            <%= form.file_field :about_us_images,
-                                multiple: true,
-                                accept: 'image/png, image/jpeg',
-                                label: "About Us Images",
-                                class: 'form-control' %>
-            <% @custom_page.about_us_images.each do |image| %>
-              <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
-            <% end %>
-            <small class="form-text text-muted">You can upload up to 2 images. <br> Images must be .png or .jpeg under 2MB </small>
-          </div>
+  <%= form.fields_for :custom_page do |custom_page_form| %>
+    <div class="row mt-3">
+      <div class="col-lg-6">
+        <div class="form-group">
+          <%= form.text_field :hero,
+                          label: "Hero",
+                          autofocus: true,
+                          placeholder: "hero text",
+                          class: "form-control" %>
         </div>
-        <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
-          <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-            <%= image_tag('custom_page_hero.png', class: "w-100", style: "border: 3px solid #754FFE;") %>
-            <%= image_tag('custom_page_adopt.png', class: "w-100") %>
-            <%= image_tag('custom_page_about_us.png', class: "w-100", style: "border: 3px solid #754FFE;") %>
-          </div>
+        <div class="form-group">
+          <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
+        </div>
+        <small class="form-text text-muted">
+          Image must be .png or .jpeg under 2MB
+        </small>
+        <div class="form-group mt-4">
+          <%= form.text_area :about,
+                         label: "About Us",
+                         placeholder: "About Us text",
+                         class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.file_field :about_us_images,
+                          multiple: true,
+                          accept: "image/png, image/jpeg",
+                          label: "About Us Images",
+                          class: "form-control" %>
+          <% @custom_page.about_us_images.each do |image| %>
+            <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
+          <% end %>
+          <small class="form-text text-muted">You can upload up to 2 images.
+            <br>
+            Images must be .png or .jpeg under 2MB
+          </small>
         </div>
       </div>
-
-      <div class="row mt-5">
-        <h3 class="mb-1">Adoptable Pet Information</h3>
-        <div class="col-lg-6 form-group">
-          <%= form.text_area :adoptable_pet_info, label: "Information for adopters", placeholder: "Anything you would like adopters to know?", class: 'form-control' %>
-        </div>
-        <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center" >
-          <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-            <%= image_tag('custom_page_adoptable_pet.png', class: "w-100", style: "border: 3px solid #754FFE;" ) %>
-          </div>
-        </div>
-      </div>
-
-      <div class="row mt-3">
-        <div class="col-lg-12">
-          <%= form.submit 'Save', class: 'btn btn-primary' %>
-          <%= link_to t('general.cancel'), :back, class: 'btn btn-outline-secondary' %>
-        </div>
-      </div>
-    <% end %>
-
-    <div class="mt-5">
-      <div class="mt-5">
-        <div class="mt-5">
-          <%= render ImageAttachmentTableComponent.new(images: @custom_page.images) %>
+      <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
+        <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
+          <%= image_tag(
+            "custom_page_hero.png",
+            class: "w-100",
+            style: "border: 3px solid #754FFE;",
+          ) %>
+          <%= image_tag("custom_page_adopt.png", class: "w-100") %>
+          <%= image_tag(
+            "custom_page_about_us.png",
+            class: "w-100",
+            style: "border: 3px solid #754FFE;",
+          ) %>
         </div>
       </div>
     </div>
+
+    <div class="row mt-5">
+      <h3 class="mb-1">Adoptable Pet Information</h3>
+      <div class="col-lg-6 form-group">
+        <%= form.text_area :adoptable_pet_info,
+                       label: "Information for adopters",
+                       placeholder: "Anything you would like adopters to know?",
+                       class: "form-control" %>
+      </div>
+      <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
+        <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
+          <%= image_tag(
+            "custom_page_adoptable_pet.png",
+            class: "w-100",
+            style: "border: 3px solid #754FFE;",
+          ) %>
+        </div>
+      </div>
+    </div>
+
+    <div class="row mt-3">
+      <div class="col-lg-12">
+        <%= form.submit "Save", class: "btn btn-primary" %>
+        <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
+      </div>
+    </div>
+  <% end %>
+
 <% end %>

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -89,7 +89,20 @@
             onmouseout: "this.style.filter='brightness(100%)'",
           ) %>
         <% end %>
-        <%= link_to root_path, class: "d-inline-block", data: { turbo_method: :get, turbo_confirm: "Unsaved changes will be lost. Are you sure you want to leave this page?" } do %>
+
+        <% pet_show_message =
+          (
+            if @example_pet
+              "Unsaved changes will be lost. Are you sure you want to leave this page?"
+            else
+              "Unsaved changes will be lost. You must create at least one Pet to view these changes live. Are you sure you want to leave this page?"
+            end
+          ) %>
+        <% pet_show_path =
+          @example_pet ? adoptable_pet_path(@example_pet) : staff_pets_path %>
+
+        <%= link_to pet_show_path, class: "d-inline-block", 
+          data: { turbo_method: :get, turbo_confirm: pet_show_message } do %>
           <%= image_tag(
             "custom_page_adoptable_pet.png",
             class: "w-100 mt-5",
@@ -97,8 +110,13 @@
             onmouseover: "this.style.filter='brightness(70%)'",
             onmouseout: "this.style.filter='brightness(100%)'",
           ) %>
+
         <% end %>
       </div>
+      <%= render partial: "organizations/shared/tooltip",
+      locals: {
+        text: "You must create at least one Pet to view these changes live",
+      } %>
 
     </div>
   </div>

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -1,69 +1,70 @@
 <%= bootstrap_form_with model: custom_page, :url => staff_custom_page_path(@custom_page), method: :patch do |form| %>
-  <div class="d-lg-flex align-items-center justify-content-between">
-    <h3 class="mb-1">Landing page details</h3>
-    <p class="text-muted mb-3" style="font-size: 12px;">Edit your landing page.
-    </p>
-  </div>
-
   <div class="row mt-3">
-    <div class="col-lg-6 card p-3">
+    <div class="col-lg-6 ">
 
-      <div class="mb-6">
-        <div class="form-group">
-          <%= form.text_field :hero,
-                          label: "Hero",
-                          autofocus: true,
-                          placeholder: "hero text",
-                          class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
-        </div>
-        <small class="form-text text-muted">
-          Image must be .png or .jpeg under 2MB
-        </small>
-      </div>
+      <h3 class="my-3">Landing page details</h3>
 
-      <div class="my-6">
-        <div class="form-group">
-          <%= form.text_area :about,
-                         label: "About Us",
-                         placeholder: "About Us text",
-                         class: "form-control" %>
-        </div>
-        <div class="form-group">
-          <%= form.file_field :about_us_images,
-                          multiple: true,
-                          accept: "image/png, image/jpeg",
-                          label: "About Us Images",
-                          class: "form-control" %>
-          <% @custom_page.about_us_images.each do |image| %>
-            <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
-          <% end %>
-          <small class="form-text text-muted">You can upload up to 2 images.
-            <br>
-            Images must be .png or .jpeg under 2MB
+      <div class="card p-3">
+        <div class="mb-6">
+          <div class="form-group">
+            <%= form.text_field :hero,
+                            label: "Hero",
+                            autofocus: true,
+                            placeholder: "hero text",
+                            class: "form-control" %>
+          </div>
+          <div class="form-group">
+            <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
+          </div>
+          <small class="form-text text-muted">
+            Image must be .png or .jpeg under 2MB
           </small>
         </div>
-      </div>
 
-      <div class="my-6">
-        <h3>Adoptable Pet Information</h3>
-        <div class="col-lg-6 form-group">
-          <%= form.text_area :adoptable_pet_info,
-                         label: "Information for adopters",
-                         placeholder: "Anything you would like adopters to know?",
-                         class: "form-control" %>
+        <div class="my-6">
+          <div class="form-group">
+            <%= form.text_area :about,
+                           label: "About Us",
+                           placeholder: "About Us text",
+                           class: "form-control" %>
+          </div>
+          <div class="form-group">
+            <%= form.file_field :about_us_images,
+                            multiple: true,
+                            accept: "image/png, image/jpeg",
+                            label: "About Us Images",
+                            class: "form-control" %>
+            <% @custom_page.about_us_images.each do |image| %>
+              <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
+            <% end %>
+            <small class="form-text text-muted">You can upload up to 2 images.
+              <br>
+              Images must be .png or .jpeg under 2MB
+            </small>
+          </div>
         </div>
-      </div>
 
-      <div class="col-lg-12">
-        <%= form.submit "Save", class: "btn btn-primary" %>
-        <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
+        <div class="my-6">
+          <h3>Adoptable Pet Information</h3>
+          <div class="col-lg-6 form-group">
+            <%= form.text_area :adoptable_pet_info,
+                           label: "Information for adopters",
+                           placeholder: "Anything you would like adopters to know?",
+                           class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="col-lg-12">
+          <%= form.submit "Save", class: "btn btn-primary" %>
+          <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
+        </div>
       </div>
     </div>
 
-    <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
+    <div class=" col-lg-6 col-12 d-none d-lg-flex flex-column align-items-center">
+      <h4>Click each section to view your changes live
+      </h4>
+      <p>*Changes must be saved before viewing</p>
       <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
         <%= link_to root_path, class: "d-inline-block", data: { turbo_method: :get, turbo_confirm: "Unsaved changes will be lost. Are you sure you want to leave this page?" } do %>
           <%= image_tag(

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -68,18 +68,24 @@
         <%= image_tag(
           "custom_page_hero.png",
           class: "w-100",
-          style: "border: 3px solid #754FFE;",
+          style: "border: 3px solid #754FFE; transition: filter 0.3s;",
+          onmouseover: "this.style.filter='brightness(70%)'",
+          onmouseout: "this.style.filter='brightness(100%)'",
         ) %>
         <%= image_tag("custom_page_adopt.png", class: "w-100") %>
         <%= image_tag(
           "custom_page_about_us.png",
           class: "w-100",
-          style: "border: 3px solid #754FFE;",
+          style: "border: 3px solid #754FFE; transition: filter 0.3s;",
+          onmouseover: "this.style.filter='brightness(70%)'",
+          onmouseout: "this.style.filter='brightness(100%)'",
         ) %>
         <%= image_tag(
           "custom_page_adoptable_pet.png",
           class: "w-100 mt-5",
-          style: "border: 3px solid #754FFE;",
+          style: "border: 3px solid #754FFE; transition: filter 0.3s;",
+          onmouseover: "this.style.filter='brightness(70%)'",
+          onmouseout: "this.style.filter='brightness(100%)'",
         ) %>
       </div>
 

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -6,41 +6,63 @@
   </div>
 
   <div class="row mt-3">
-    <div class="col-lg-6">
-      <div class="form-group">
-        <%= form.text_field :hero,
-                        label: "Hero",
-                        autofocus: true,
-                        placeholder: "hero text",
-                        class: "form-control" %>
-      </div>
-      <div class="form-group">
-        <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
-      </div>
-      <small class="form-text text-muted">
-        Image must be .png or .jpeg under 2MB
-      </small>
-      <div class="form-group mt-4">
-        <%= form.text_area :about,
-                       label: "About Us",
-                       placeholder: "About Us text",
-                       class: "form-control" %>
-      </div>
-      <div class="form-group">
-        <%= form.file_field :about_us_images,
-                        multiple: true,
-                        accept: "image/png, image/jpeg",
-                        label: "About Us Images",
-                        class: "form-control" %>
-        <% @custom_page.about_us_images.each do |image| %>
-          <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
-        <% end %>
-        <small class="form-text text-muted">You can upload up to 2 images.
-          <br>
-          Images must be .png or .jpeg under 2MB
+    <div class="col-lg-6 card p-3">
+
+      <div class="mb-6">
+        <div class="form-group">
+          <%= form.text_field :hero,
+                          label: "Hero",
+                          autofocus: true,
+                          placeholder: "hero text",
+                          class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
+        </div>
+        <small class="form-text text-muted">
+          Image must be .png or .jpeg under 2MB
         </small>
       </div>
+
+      <div class="my-6">
+        <div class="form-group">
+          <%= form.text_area :about,
+                         label: "About Us",
+                         placeholder: "About Us text",
+                         class: "form-control" %>
+        </div>
+        <div class="form-group">
+          <%= form.file_field :about_us_images,
+                          multiple: true,
+                          accept: "image/png, image/jpeg",
+                          label: "About Us Images",
+                          class: "form-control" %>
+          <% @custom_page.about_us_images.each do |image| %>
+            <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
+          <% end %>
+          <small class="form-text text-muted">You can upload up to 2 images.
+            <br>
+            Images must be .png or .jpeg under 2MB
+          </small>
+        </div>
+      </div>
+
+      <div class="my-6">
+        <h3>Adoptable Pet Information</h3>
+        <div class="col-lg-6 form-group">
+          <%= form.text_area :adoptable_pet_info,
+                         label: "Information for adopters",
+                         placeholder: "Anything you would like adopters to know?",
+                         class: "form-control" %>
+        </div>
+      </div>
+
+      <div class="col-lg-12">
+        <%= form.submit "Save", class: "btn btn-primary" %>
+        <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
+      </div>
     </div>
+
     <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
       <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
         <%= image_tag(
@@ -54,33 +76,13 @@
           class: "w-100",
           style: "border: 3px solid #754FFE;",
         ) %>
-      </div>
-    </div>
-  </div>
-
-  <div class="row mt-5">
-    <h3 class="mb-1">Adoptable Pet Information</h3>
-    <div class="col-lg-6 form-group">
-      <%= form.text_area :adoptable_pet_info,
-                     label: "Information for adopters",
-                     placeholder: "Anything you would like adopters to know?",
-                     class: "form-control" %>
-    </div>
-    <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
-      <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
         <%= image_tag(
           "custom_page_adoptable_pet.png",
-          class: "w-100",
+          class: "w-100 mt-5",
           style: "border: 3px solid #754FFE;",
         ) %>
       </div>
-    </div>
-  </div>
 
-  <div class="row mt-3">
-    <div class="col-lg-12">
-      <%= form.submit "Save", class: "btn btn-primary" %>
-      <%= link_to t("general.cancel"), :back, class: "btn btn-outline-secondary" %>
     </div>
   </div>
 

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -65,28 +65,38 @@
 
     <div class="col-lg-6 col-12 d-none d-lg-flex justify-content-center">
       <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-        <%= image_tag(
-          "custom_page_hero.png",
-          class: "w-100",
-          style: "border: 3px solid #754FFE; transition: filter 0.3s;",
-          onmouseover: "this.style.filter='brightness(70%)'",
-          onmouseout: "this.style.filter='brightness(100%)'",
-        ) %>
-        <%= image_tag("custom_page_adopt.png", class: "w-100") %>
-        <%= image_tag(
-          "custom_page_about_us.png",
-          class: "w-100",
-          style: "border: 3px solid #754FFE; transition: filter 0.3s;",
-          onmouseover: "this.style.filter='brightness(70%)'",
-          onmouseout: "this.style.filter='brightness(100%)'",
-        ) %>
-        <%= image_tag(
-          "custom_page_adoptable_pet.png",
-          class: "w-100 mt-5",
-          style: "border: 3px solid #754FFE; transition: filter 0.3s;",
-          onmouseover: "this.style.filter='brightness(70%)'",
-          onmouseout: "this.style.filter='brightness(100%)'",
-        ) %>
+        <%= link_to root_path, class: "d-inline-block", data: { turbo_method: :get, turbo_confirm: "Unsaved changes will be lost. Are you sure you want to leave this page?" } do %>
+          <%= image_tag(
+            "custom_page_hero.png",
+            class: "w-100",
+            style: "border: 3px solid #754FFE; transition: filter 0.3s;",
+            onmouseover: "this.style.filter='brightness(70%)'",
+            onmouseout: "this.style.filter='brightness(100%)'",
+          ) %>
+        <% end %>
+
+        <%= link_to home_index_path(anchor: "about_us"), 
+                                    class: "d-inline-block",
+                                    data: { turbo: :false},
+                                    onclick: "return confirm('Unsaved changes will be lost. Are you sure you want to leave this page?');" do %>
+          <%= image_tag("custom_page_adopt.png", class: "w-100") %>
+          <%= image_tag(
+            "custom_page_about_us.png",
+            class: "w-100",
+            style: "border: 3px solid #754FFE; transition: filter 0.3s;",
+            onmouseover: "this.style.filter='brightness(70%)'",
+            onmouseout: "this.style.filter='brightness(100%)'",
+          ) %>
+        <% end %>
+        <%= link_to root_path, class: "d-inline-block", data: { turbo_method: :get, turbo_confirm: "Unsaved changes will be lost. Are you sure you want to leave this page?" } do %>
+          <%= image_tag(
+            "custom_page_adoptable_pet.png",
+            class: "w-100 mt-5",
+            style: "border: 3px solid #754FFE; transition: filter 0.3s;",
+            onmouseover: "this.style.filter='brightness(70%)'",
+            onmouseout: "this.style.filter='brightness(100%)'",
+          ) %>
+        <% end %>
       </div>
 
     </div>

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -89,13 +89,12 @@
             onmouseout: "this.style.filter='brightness(100%)'",
           ) %>
         <% end %>
-
         <% pet_show_message =
           (
             if @example_pet
-              "Unsaved changes will be lost. Are you sure you want to leave this page?"
+              t(".unsaved_changes")
             else
-              "Unsaved changes will be lost. You must create at least one Pet to view these changes live. Are you sure you want to leave this page?"
+              "#{t(".pet_show_info")} #{t(".unsaved_changes")}"
             end
           ) %>
         <% pet_show_path =
@@ -115,7 +114,7 @@
       </div>
       <%= render partial: "organizations/shared/tooltip",
       locals: {
-        text: "You must create at least one Pet to view these changes live",
+        text: t(".pet_show_info"),
       } %>
 
     </div>

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -2,7 +2,8 @@
   <div class="row mt-3">
     <div class="col-lg-6 ">
 
-      <h3 class="my-3">Landing page details</h3>
+      <h3 class="my-3"><%= t(".details_header") %>
+      </h3>
 
       <div class="card p-3">
         <div class="mb-6">
@@ -17,7 +18,7 @@
             <%= form.file_field :hero_image, label: "Hero Image", class: "form-control" %>
           </div>
           <small class="form-text text-muted">
-            Image must be .png or .jpeg under 2MB
+            <%= t(".image_requirements") %>
           </small>
         </div>
 
@@ -37,9 +38,9 @@
             <% @custom_page.about_us_images.each do |image| %>
               <%= form.hidden_field :about_us_images, multiple: true, value: image.signed_id %>
             <% end %>
-            <small class="form-text text-muted">You can upload up to 2 images.
+            <small class="form-text text-muted"><%= t(".upload_limit") %>
               <br>
-              Images must be .png or .jpeg under 2MB
+              <%= t(".image_requirements") %>
             </small>
           </div>
         </div>
@@ -62,11 +63,14 @@
     </div>
 
     <div class=" col-lg-6 col-12 d-none d-lg-flex flex-column align-items-center">
-      <h4>Click each section to view your changes live
+      <h4><%= t(".view_changes") %>
       </h4>
-      <p>*Changes must be saved before viewing</p>
+      <p><%= t(".changes_must_be_saved") %>
+      </p>
       <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-        <%= link_to root_path, class: "d-inline-block", data: { turbo_method: :get, turbo_confirm: "Unsaved changes will be lost. Are you sure you want to leave this page?" } do %>
+        <%= link_to root_path, class: "d-inline-block",
+                                data: { turbo_method: :get,
+                                        turbo_confirm: t(".unsaved_changes") } do %>
           <%= image_tag(
             "custom_page_hero.png",
             class: "w-100",
@@ -76,11 +80,11 @@
           ) %>
         <% end %>
 
+        <%= image_tag("custom_page_adopt.png", class: "w-100") %>
         <%= link_to home_index_path(anchor: "about_us"), 
                                     class: "d-inline-block",
                                     data: { turbo: :false},
-                                    onclick: "return confirm('Unsaved changes will be lost. Are you sure you want to leave this page?');" do %>
-          <%= image_tag("custom_page_adopt.png", class: "w-100") %>
+                                    onclick: "return confirm('#{t(".unsaved_changes")}' );" do %>
           <%= image_tag(
             "custom_page_about_us.png",
             class: "w-100",

--- a/app/views/organizations/staff/custom_pages/_form.html.erb
+++ b/app/views/organizations/staff/custom_pages/_form.html.erb
@@ -68,7 +68,7 @@
       <p><%= t(".changes_must_be_saved") %>
       </p>
       <div class="col-10 shadow-lg mb-auto" style="max-width: 500px">
-        <%= link_to root_path, class: "d-inline-block",
+        <%= link_to home_index_path, class: "d-inline-block",
                                 data: { turbo_method: :get,
                                         turbo_confirm: t(".unsaved_changes") } do %>
           <%= image_tag(
@@ -81,6 +81,9 @@
         <% end %>
 
         <%= image_tag("custom_page_adopt.png", class: "w-100") %>
+
+        <%# Using turbo confirm strips the anchor from the url. %>
+        <%# This is resolved by disabling turbo and adding the onclick to display the confirm message %>
         <%= link_to home_index_path(anchor: "about_us"), 
                                     class: "d-inline-block",
                                     data: { turbo: :false},

--- a/app/views/organizations/staff/custom_pages/edit.html.erb
+++ b/app/views/organizations/staff/custom_pages/edit.html.erb
@@ -1,4 +1,3 @@
-
 <%= render DashboardPageComponent.new(crumb: :custom_page) do |c| %>
   <% c.with_header_title { "Custom Page" } %>
   <% c.with_body do %>
@@ -6,6 +5,14 @@
       <div>
         <div>
           <%= render "form", custom_page: @custom_page %>
+
+          <div class="mt-6">
+            <div class="mt-6">
+              <div class="mt-6">
+                <%= render ImageAttachmentTableComponent.new(images: @custom_page.images) %>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -450,8 +450,13 @@ en:
         update:
           success: "Page text updated successfully!"
         form:
+          details_header: "Landing page details"
           unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave this page?"
           pet_show_info: "You must create at least one Pet to view these changes live."
+          view_changes: "Click each section to view your changes live"
+          changes_must_be_saved: "*Changes must be saved before viewing" 
+          image_requirements: "Image must be .png or .jpeg under 2MB"
+          upload_limit: "You can upload up to 2 images."
       matches:
         create:
           success: "Pet successfully adopted."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -449,6 +449,9 @@ en:
       custom_pages:
         update:
           success: "Page text updated successfully!"
+        form:
+          unsaved_changes: "Unsaved changes will be lost. Are you sure you want to leave this page?"
+          pet_show_info: "You must create at least one Pet to view these changes live."
       matches:
         create:
           success: "Pet successfully adopted."


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
Resolves #1468 
# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
This adds links to the pages represented by the images. I added a darkening to the image on mouseover to give indication to the user. A confirmation is presented before navigating from the page. A tooltip was added below the `Additional Pet Information` section to advise the user that they must have at least one pet created to view it live. The same warning is show on the confirm dialog. If the user proceeds they are directed to the `staff/pets` page. If at least one unadopted pet is in the database, they are directed to the pet show page.

Form inputs were added to a card. I also removed unused code.  The image section was already being hidden on mobile so I kept that the same. I think that makes the most sense.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
[Screencast from 2025-06-28 08-04-37.webm](https://github.com/user-attachments/assets/f0b70552-e7ad-4604-a126-7c885dd03cd6)

