### PR TITLE
1486 - Refactor default pet tasks table to include empty state handling

### DIFF
--- a/app/views/organizations/staff/default_pet_tasks/_default_pet_tasks_table.html.erb
+++ b/app/views/organizations/staff/default_pet_tasks/_default_pet_tasks_table.html.erb
@@ -13,34 +13,38 @@
           </tr>
         </thead>
         <tbody>
-          <% @default_pet_tasks.each do |task| %>
-            <tr>
-              <td>
-                <%= task.name %>
-              </td>
-              <td>
-                <%= task.description %>
-              </td>
-              <td>
-                <%= task.human_enum_name(:species) %>
-              </td>
-              <td>
-                <%= task.due_in_days ? pluralize(task.due_in_days, "day") : "" %>
-              </td>
-              <td>
-                <%= task.recurring? ? t('general.yes') : t('general.no') %>
-              </td>
-              <% if allowed_to?(:manage?, task) %>
+          <% if @default_pet_tasks.present?%>
+            <% @default_pet_tasks.each do |task| %>
+              <tr>
                 <td>
-                  <div class="text-right">
-                    <div class="d-flex align-items-center justify-content-end">
-                      <%= link_to t('general.edit'), edit_staff_default_pet_task_path(task), class: 'btn btn-warning m-2' %>
-                      <%= link_to t('general.delete'), staff_default_pet_task_path(task), class: 'btn btn-danger m-2', data: { turbo_method: "delete", turbo_confirm: t('.are_you_sure_delete') } %>
-                    </div>
-                  </div>
+                  <%= task.name %>
                 </td>
-              <% end %>
-            </tr>
+                <td>
+                  <%= task.description %>
+                </td>
+                <td>
+                  <%= task.human_enum_name(:species) %>
+                </td>
+                <td>
+                  <%= task.due_in_days ? pluralize(task.due_in_days, "day") : "" %>
+                </td>
+                <td>
+                  <%= task.recurring? ? t('general.yes') : t('general.no') %>
+                </td>
+                <% if allowed_to?(:manage?, task) %>
+                  <td>
+                    <div class="text-right">
+                      <div class="d-flex align-items-center justify-content-end">
+                        <%= link_to t('general.edit'), edit_staff_default_pet_task_path(task), class: 'btn btn-warning m-2' %>
+                        <%= link_to t('general.delete'), staff_default_pet_task_path(task), class: 'btn btn-danger m-2', data: { turbo_method: "delete", turbo_confirm: t('.are_you_sure_delete') } %>
+                      </div>
+                    </div>
+                  </td>
+                <% end %>
+              </tr>
+            <% end %>
+          <% else %>
+            <%= render partial: "shared/empty_state", locals: {text: t(".empty_state")} %>
           <% end %>
         </tbody>
       </table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -509,7 +509,7 @@ en:
           default_pet_tasks: "Default Pet Tasks"
           create_default_task: "Create Default Task"
           are_you_sure_delete: "Are you sure you want to delete this default pet task?"
-          empty_state: "No default pet tasks found"
+          empty_state: "Tasks created here will be added to every new pet you create. They will not be added to existing pets."
         default_pet_task_cards:
           name: "Name"
           description: "Description"


### PR DESCRIPTION
# 🔗 Issue
#1486 

# ✍️ Description
-> Updated the Message For the Empty State.

# 📷 Screenshots/Demos

![image](https://github.com/user-attachments/assets/6ac45c37-72c7-4e0d-891b-9a839d61cbb4)
