### PR TITLE
Empty state for tasks and applications

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -47,10 +47,10 @@ label.required:after {
 
 
 // Custom styling for only-child psuedo class
-.list-group .only-child-block:not(:only-child) {
+.only-child-block:not(:only-child) {
   display: none;
 }
 
-.list-group .only-child-block:only-child {
+.only-child-block:only-child {
   display: block;
 }

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -44,3 +44,13 @@ label.required:after {
     }
   }
 }
+
+
+// Custom styling for only-child psuedo class
+.list-group .only-child-block:not(:only-child) {
+  display: none;
+}
+
+.list-group .only-child-block:only-child {
+  display: block;
+}

--- a/app/javascript/controllers/toggle_completed_controller.js
+++ b/app/javascript/controllers/toggle_completed_controller.js
@@ -1,17 +1,26 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class ToggleCompletedController extends Controller {
+  static classes = ["show"];
+
   connect() {
-    this.completedTasks = document.querySelectorAll('.bg-success-subtle');
+    this.completedTasks = document.querySelectorAll('.task-list .bg-success-subtle');
+    this.taskFrames = document.querySelectorAll('.task-list turbo-frame');
+    this.emptyState = document.querySelector('.task-list li.only-child-block')
   }
 
   toggleCompletedTasks() {
     const isChecked = this.element.checked;
     if (isChecked) {
+      this.emptyState.classList.remove(this.showClass);
       this.showCompletedTasks();
     } else {
       this.hideCompletedTasks();
+      if (this.#requiresEmptyState()) {
+        this.emptyState.classList.add(this.showClass);
+      }
     }
+
   }
 
   hideCompletedTasks() {
@@ -24,5 +33,13 @@ export default class ToggleCompletedController extends Controller {
     this.completedTasks.forEach((item) => {
       item.classList.remove('d-none');
     });
+  }
+
+  #requiresEmptyState() {
+    if (this.completedTasks.length == this.taskFrames.length) {
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/app/views/organizations/staff/pets/tabs/_applications.html.erb
+++ b/app/views/organizations/staff/pets/tabs/_applications.html.erb
@@ -29,7 +29,7 @@
             <%= render 'organizations/staff/pets/tabs/partials/application_info_table_row', app: app %>
           <% end %>
           <tr class="only-child-block">
-            <td class="text-center w-100 align-middle">
+            <td>
               There are no applications for this pet... yet!
             </td>
           </tr>

--- a/app/views/organizations/staff/pets/tabs/_applications.html.erb
+++ b/app/views/organizations/staff/pets/tabs/_applications.html.erb
@@ -4,7 +4,7 @@
     <div class="d-flex card-header align-items-center">
       <%= link_to staff_pet_path(pet) do %>
         <%= render PetAvatarComponent.new(pet) %>
-      <% end %> 
+      <% end %>
       <h4 class="mb-0 ms-3"><%= link_to pet.name, staff_pet_path(pet), class: "link-underline link-underline-opacity-0" %></h4>
     </div>
   <% end %>
@@ -28,6 +28,11 @@
           <% applications.each do |app|%>
             <%= render 'organizations/staff/pets/tabs/partials/application_info_table_row', app: app %>
           <% end %>
+          <tr class="only-child-block">
+            <td class="text-center w-100 align-middle">
+              There are no applications for this pet... yet!
+            </td>
+          </tr>
         </tbody>
     </table>
   </div>

--- a/app/views/organizations/staff/tasks/_task.html.erb
+++ b/app/views/organizations/staff/tasks/_task.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag task do %>
+<%= turbo_frame_tag task, data: { toggle_completed_target: "taskFrame" } do %>
   <li class="list-group-item <%= class_names({ 'bg-danger-subtle': task.overdue?, 'bg-success-subtle': task.completed }) %>">
     <div class="d-flex justify-content-between
               align-items-center">

--- a/app/views/organizations/staff/tasks/index.html.erb
+++ b/app/views/organizations/staff/tasks/index.html.erb
@@ -25,14 +25,16 @@
                     id="flexSwitchCheckChecked"
                     checked
                     data-controller="toggle-completed"
+                    data-toggle-completed-show-class="d-block"
                     data-action="change->toggle-completed#toggleCompletedTasks">
                 </div>
               </div>
           </div>
           <%= turbo_frame_tag Task.new %>
         </div>
-        <ul class="list-group">
+        <ul class="list-group task-list">
           <%= render @tasks %>
+          <li class="only-child-block text-center px-2 py-4">There are no active tasks for this pet.</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
# 🔗 Issue
Issue #1485 

# ✍️ Description
We add an empty state for tasks and applications that primarily uses CSS to leverage the `:only-child` psuedo selector.

Additional changes were required for the toggling of empty state when toggling tasks, so changes were made to the `toggle-completed` Stimulus controller to add a hide class you can input from HTML, as well as checking whether you were toggling all tasks or not to decide if we needed the empty state to show up.

# 📷 Screenshots/Demos
Tasks New - Empty
![image](https://github.com/user-attachments/assets/03ecfe50-2048-4948-9c6c-29bf5411f8fa)

Applications New - Empty
![image](https://github.com/user-attachments/assets/a60d4d28-e900-4072-83d2-268d970691b4)

All Completed Tasks - Before Toggle
![image](https://github.com/user-attachments/assets/5247e630-d9d7-4ad7-88e1-f76c0603aa50)

All Completed Tasks - After Toggle
![image](https://github.com/user-attachments/assets/da277d52-bb5b-48a4-ba21-2026c08ca6a3)