### PR TITLE
Move tabs to viewcomponent

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -2,6 +2,7 @@ require "dry-initializer"
 require "dry-types"
 
 class ApplicationComponent < ViewComponent::Base
+  include Turbo::FramesHelper
   extend Dry::Initializer
 
   module Types

--- a/app/components/tabs_component.html.erb
+++ b/app/components/tabs_component.html.erb
@@ -1,0 +1,41 @@
+<nav>
+  <div
+    class="nav nav-tabs d-flex-inline flex-column flex-sm-row"
+    id="nav-tab"
+    role="tablist"
+  >
+    <% tabs.each_with_index do |tab, i| %>
+      <button
+        class="nav-link text-sm-center <%= 'active' if tab[:active] || i == 0 %>"
+        id="nav-<%= tab[:id] %>"
+        data-bs-toggle="tab"
+        data-bs-target="#<%= tab[:id] %>"
+        type="button"
+        role="tab"
+        aria-controls="<%= tab[:id] %>"
+        aria-selected="<%= (tab[:active] || i == 0).to_s %>"
+      >
+        <%= tab[:label] %>
+      </button>
+    <% end %>
+  </div>
+</nav>
+
+<div class="tab-content p-3" id="nav-tabContent">
+  <% tabs.each_with_index do |tab, i| %>
+    <% classes = "tab-pane fade" %>
+    <% classes += " show active" if tab[:active] || i == 0 %>
+
+    <%= turbo_frame_tag "#{tab[:id]}",
+          src: tab[:src],
+          class: classes,
+          role: "tabpanel",
+          aria_labelledby: tab[:id], 
+          tabindex: 0,
+          loading: tab[:src] ? "lazy" : nil do %>
+      <% if tab[:partial] %>
+        <%= render partial: tab[:partial], locals: tab[:locals] || {} %>
+      <% end %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/tabs_component.rb
+++ b/app/components/tabs_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class TabsComponent < ApplicationComponent
+  attr_reader :tabs
+
+  def initialize(tabs:)
+    @tabs = tabs
+  end
+end

--- a/app/views/organizations/people/_details.html.erb
+++ b/app/views/organizations/people/_details.html.erb
@@ -23,7 +23,11 @@
         </p>
       </div>
     </div>
-    <div class="border-top row mt-3 border-bottom mb-3 g-0">
+    <div
+      class="
+        border-top d-flex flex-column flex-sm-row mt-3 border-bottom mb-3 g-0
+      "
+    >
       <div class="col">
         <div class="pe-1 ps-2 py-3">
           <h5 class="mb-0">

--- a/app/views/organizations/people/show.html.erb
+++ b/app/views/organizations/people/show.html.erb
@@ -1,52 +1,24 @@
 <%= render DashboardPageComponent.new(crumb: :person, crumb_options: @person) do |c| %>
   <% c.with_header_title { t(:people) } %>
   <% c.with_body do %>
-    <nav>
-      <div
-        class="nav nav-tabs d-flex-inline flex-column flex-sm-row"
-        id="nav-tab"
-        role="tablist"
-      >
-        <button
-          class="nav-link active text-sm-center"
-          id="nav-details"
-          data-bs-toggle="tab"
-          data-bs-target="#details"
-          type="button"
-          role="tab"
-          aria-controls="nav-details"
-          aria-selected="true"
-        ><%= t(".details") %>
-        </button>
-        <button
-          class="nav-link text-sm-center"
-          id="nav-form-submissions"
-          data-bs-toggle="tab"
-          data-bs-target="#form_submissions"
-          type="button"
-          role="tab"
-          aria-controls="nav-details"
-          aria-selected="true"
-        ><%= t(".form_submissions") %>
-        </button>
-      </div>
-    </nav>
-    <div class="tab-content p-3" id="nav-tabContent">
-      <%= turbo_frame_tag "details",
-        class: "tab-pane fade show active", 
-        role:"tabpanel",
-        aria_labelledby:"details",
-        tabindex:"0" do %>
-        <%= render "details", person: @person %>
-      <% end %>
-      <%= turbo_frame_tag "form_submissions",
-        src: staff_person_form_submissions_path(@person),
-        loading: "lazy",
-        class: "tab-pane fade", 
-        role:"tabpanel",
-        aria_labelledby:"form_subbmissions",
-        tabindex:"0" do %>
-      <% end %>
-    </div>
+
+    <%= render TabsComponent.new(
+      tabs: [
+        {
+          id: "details",
+          label: t(".details"),
+          partial: "details",
+          locals: {
+            person: @person,
+          },
+          active: true,
+        },
+        {
+          id: "form_submissions",
+          label: t(".form_submissions"),
+          src: staff_person_form_submissions_path(@person),
+        },
+      ],
+    ) %>
   <% end %>
 <% end %>

--- a/test/components/tabs_component_test.rb
+++ b/test/components/tabs_component_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class TabsComponentTest < ViewComponent::TestCase
+  should "render nav tabs and content panes for each tab" do
+    tabs = [
+      {id: "tab-1", label: "Tab 1", src: "/fake/tab1", partial: nil},
+      {id: "tab-2", label: "Tab 2", src: "/fake/tab2", partial: nil, active: true},
+      {id: "tab-3", label: "Tab 3", src: nil, partial: "fake/partial", locals: {foo: "bar"}}
+    ]
+
+    TabsComponent.any_instance.stubs(:render).returns("<!-- stubbed partial -->")
+
+    render_inline(TabsComponent.new(tabs: tabs))
+
+    # Navigation tab buttons
+    assert_selector("nav div#nav-tab button", count: 3)
+    assert_selector("button#nav-tab-1", text: "Tab 1")
+    assert_selector("button#nav-tab-2.active", text: "Tab 2")
+    assert_selector("button#nav-tab-3", text: "Tab 3")
+
+    # Tab panes
+    assert_selector("div#nav-tabContent.tab-content .tab-pane", count: 3)
+    assert_selector("turbo-frame#tab-1[src='/fake/tab1']")
+    assert_selector("turbo-frame#tab-2[src='/fake/tab2'].show.active")
+    assert_selector("turbo-frame#tab-3:not([src])", text: /stubbed partial/)
+  end
+
+  should "mark first tab active if none are marked active" do
+    tabs = [
+      {id: "first", label: "First", src: "/fake/first"},
+      {id: "second", label: "Second", src: "/fake/second"}
+    ]
+
+    render_inline(TabsComponent.new(tabs: tabs))
+
+    assert_selector("button#nav-first.active")
+    assert_selector("turbo-frame#first.show.active")
+  end
+end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Bootstrap Tabs are currently used on the Person Show page using only two tabs. This change moves the relevant code to a ViewComponent to reduce duplication and facilitate adding additional tabs in the future.

An additional small change was made to display the person attributes in a column for small screen to match the responsive design of the tabs.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

<img width="773" height="1559" alt="Screenshot from 2025-07-11 10-37-02" src="https://github.com/user-attachments/assets/295fd189-05c0-48f4-96e6-63ee6be9734e" />

