### PR TITLE
tweak org footer

### DIFF
--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -8,9 +8,8 @@
           <h3>
             <%= t(".organization_name", name: Current.tenant.name) %>
           </h3>
-          <%= render "shared/powered_by" %>
-          <div class="mt-2">
 
+          <div class="mt-2">
             <p>
               <%= t(".call") %>
               <%= link_to t(".action"),
@@ -30,7 +29,7 @@
       <div class="offset-lg-1 col-lg-2 col-md-3 col-6">
         <div class="mb-4">
           <!-- list -->
-          <h3 class="fw-bold mb-3"><%= t(".company") %></h3>
+          <h3 class="fw-bold mb-3"><%= t(".socials") %></h3>
           <ul class="list-unstyled nav nav-footer flex-column nav-x-0">
             <% if Current.tenant&.facebook_url.present? || Current.tenant&.instagram_url.present? %>
               <li class="d-flex gap-3">
@@ -97,9 +96,9 @@
         </div>
       </div>
     </div>
-    <div class="row align-items-center g-0 border-top py-2">
+    <div class="row flex align-items-center g-0 border-top py-2">
       <!-- Desc -->
-      <div class="col-lg-4 col-md-5 col-12">
+      <div class="col-lg-3 col-md-3 col-12 d-flex justify-content-center">
         <span>
           ©
           <span id="copyright">
@@ -109,15 +108,16 @@
         </span>
       </div>
       <!-- Links -->
-      <div class="col-12 col-md-7 col-lg-8 d-md-flex justify-content-end">
-        <nav class="nav nav-footer">
+      <div class="col-12 col-md-4 col-lg-6 d-md-flex my-2 my-md-0">
+        <nav class="nav nav-footer justify-content-center w-100">
           <%= link_to t(".policy"), privacy_policy_path, target: "_blank", class: "nav-link" %>
           <%= link_to t(".cookie"), cookie_policy_path, target: "_blank", class: "nav-link" %>
-          <%= link_to t(".terms"),
-          terms_and_conditions_path,
-          target: "_blank",
-          class: "nav-link" %>
+          <%= link_to t(".terms"), terms_and_conditions_path, target: "_blank", class: "nav-link" %>
         </nav>
+      </div>
+
+      <div class="col-12 col-md-4 col-lg-3 d-flex justify-content-center">
+        <%= render "shared/powered_by" %>
       </div>
     </div>
   </div>

--- a/app/views/layouts/shared/_footer.html.erb
+++ b/app/views/layouts/shared/_footer.html.erb
@@ -96,9 +96,17 @@
         </div>
       </div>
     </div>
-    <div class="row flex align-items-center g-0 border-top py-2">
-      <!-- Desc -->
-      <div class="col-lg-3 col-md-3 col-12 d-flex justify-content-center">
+    <div class="row flex align-items-center border-top py-2 justify-content-between">
+      <!-- Links -->
+      <div class="col-12 col-lg-4">
+        <nav class="nav nav-footer justify-content-start w-100 my-lg-0 my-2">
+          <%= link_to t(".policy"), privacy_policy_path, target: "_blank", class: "nav-link ps-0" %>
+          <%= link_to t(".cookie"), cookie_policy_path, target: "_blank", class: "nav-link ps-0" %>
+          <%= link_to t(".terms"), terms_and_conditions_path, target: "_blank", class: "nav-link ps-0" %>
+        </nav>
+      </div>
+
+      <div class="col-12 col-lg-4 d-flex justify-content-start justify-content-lg-center">
         <span>
           ©
           <span id="copyright">
@@ -107,16 +115,8 @@
           <%= t(".rights") %>
         </span>
       </div>
-      <!-- Links -->
-      <div class="col-12 col-md-4 col-lg-6 d-md-flex my-2 my-md-0">
-        <nav class="nav nav-footer justify-content-center w-100">
-          <%= link_to t(".policy"), privacy_policy_path, target: "_blank", class: "nav-link" %>
-          <%= link_to t(".cookie"), cookie_policy_path, target: "_blank", class: "nav-link" %>
-          <%= link_to t(".terms"), terms_and_conditions_path, target: "_blank", class: "nav-link" %>
-        </nav>
-      </div>
 
-      <div class="col-12 col-md-4 col-lg-3 d-flex justify-content-center">
+      <div class="col-12 col-lg-4 d-flex justify-content-end">
         <%= render "shared/powered_by" %>
       </div>
     </div>

--- a/app/views/shared/_powered_by.html.erb
+++ b/app/views/shared/_powered_by.html.erb
@@ -1,12 +1,12 @@
 <% url ||= "/" %>
 <% target ||= "_self" %>
 
-<div class="d-flex align-items-end gap-3">
+<div class="d-flex align-items-end gap-2">
   <div class="fst-italic text-black fs-6">Powered By</div>
   <%= link_to url, target: target , class: "link-primary link-opacity-25-hover" do %>
     <div class="fs-4 fw-medium">
       <%= t("root.index.title") %>
     </div>
-    <div class="fw-light fs-6"><%= t("root.index.sub_title") %></div>
+    <div class="fw-light fs-6 mt-n1"><%= t("root.index.sub_title") %></div>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -180,9 +180,9 @@ en:
     shared:
       footer:
         organization_name: "%{name}"
-        call: "If you are a pet adoption or foster organization and want a website like this one, for free,"
+        call: "If you want a website like this one, for free,"
         action: "Click Here"
-        company: "Company"
+        socials: "Socials"
         rights: "Pet-Rescue, Inc. All Rights Reserved"
         policy: "Privacy Policy"
         cookie: "Cookie Notice"


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
Just proposing re-designing the org footer a bit, and the powered by logo to just smush it a bit closer together. Style could be finessed at smallest width, but this is a movement to what I think it a slightly better layout in the footer. Thoughts?
Lg
<img width="1426" height="287" alt="image" src="https://github.com/user-attachments/assets/6cdf0201-1998-4a50-928e-c7b04aa5601d" />

Md
<img width="971" height="462" alt="image" src="https://github.com/user-attachments/assets/f880a2d7-e818-497f-a1be-8e17b0f72543" />

Sm
<img width="492" height="565" alt="image" src="https://github.com/user-attachments/assets/5dcc7f1f-ad61-4c4a-9403-5079d624d104" />


# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
