### PR TITLE
Add active to Org and small fixes

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,13 +1,21 @@
 class StaticPagesController < ApplicationController
   skip_before_action :authenticate_user!
-  skip_verify_authorized only: %i[about_us cookie_policy donate partners
-    privacy_policy terms_and_conditions organizations]
 
-  before_action :require_no_tenant, only: [:about_us, :partners]
+  skip_verify_authorized only: %i[
+    about_us
+    cookie_policy
+    donate
+    partners
+    privacy_policy
+    terms_and_conditions
+    organizations
+  ]
+
+  before_action :require_no_tenant, only: [:about_us, :partners, :organizations]
 
   def home
-    if !current_tenant
-      render :no_tenant and return
+    if Current.organization.blank?
+      render :no_tenant
     end
   end
 
@@ -30,15 +38,14 @@ class StaticPagesController < ApplicationController
   end
 
   def organizations
-    @organizations = Organization
-      .includes(:custom_page, :locations)
+    @organizations = Organization.active.includes(:custom_page, :locations)
   end
 
   private
 
   def require_no_tenant
-    unless Current.organization.blank?
-      render "errors/not_found", status: :not_found and return
+    if Current.organization.present?
+      render "errors/not_found", status: :not_found
     end
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -3,6 +3,7 @@
 # Table name: organizations
 #
 #  id                :bigint           not null, primary key
+#  active            :boolean          default(TRUE), not null
 #  donation_url      :text
 #  email             :string           not null
 #  external_form_url :text
@@ -16,7 +17,8 @@
 #
 # Indexes
 #
-#  index_organizations_on_slug  (slug) UNIQUE
+#  index_organizations_on_active  (active)
+#  index_organizations_on_slug    (slug) UNIQUE
 #
 class Organization < ApplicationRecord
   include Avatarable
@@ -45,4 +47,6 @@ class Organization < ApplicationRecord
   validates :facebook_url, url: true, allow_blank: true
   validates :instagram_url, url: true, allow_blank: true
   validates :donation_url, url: true, allow_blank: true
+
+  scope :active, -> { where(active: true) }
 end

--- a/app/views/layouts/shared/_navbar.html.erb
+++ b/app/views/layouts/shared/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg bg-transparent shadow-none px-0 py-3">
+<nav class="navbar navbar-expand-lg bg-white shadow-none px-0 py-3">
   <div class="container-fluid px-4">
     <div class="d-flex align-items-center order-lg-3">
       <div>

--- a/app/views/static_pages/organizations.html.erb
+++ b/app/views/static_pages/organizations.html.erb
@@ -2,7 +2,7 @@
   <div class="container mt-md-5">
     <h1 class="text-center fw-bold">Welcome to Homeward Tails</h1>
     <p class="lead text-center mt-3">
-      Adopt pets from all <%= @organizations.count %> Homeward Tails organizations with a single account
+      Adopt pets from all <%= @organizations.count > 1 ? @organizations.count : nil %> Homeward Tails organizations with a single account
     </p>
   </div>
 </section>

--- a/db/migrate/20250712211752_add_active_column_to_organizations.rb
+++ b/db/migrate/20250712211752_add_active_column_to_organizations.rb
@@ -1,0 +1,8 @@
+class AddActiveColumnToOrganizations < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured do
+      add_column :organizations, :active, :boolean, default: true, null: false
+      add_index :organizations, :active
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_04_224628) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_12_211752) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -199,6 +199,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_04_224628) do
     t.text "facebook_url"
     t.text "instagram_url"
     t.text "external_form_url"
+    t.boolean "active", default: true, null: false
+    t.index ["active"], name: "index_organizations_on_active"
     t.index ["slug"], name: "index_organizations_on_slug", unique: true
   end
 

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -54,4 +54,21 @@ class OrganizationTest < ActiveSupport::TestCase
       subject.save
     end
   end
+
+  context "defaults" do
+    should "have active default to true" do
+      organization = Organization.new
+      assert organization.active
+    end
+  end
+
+  context "scopes" do
+    should "return only active organizations" do
+      active_org = create(:organization, active: true)
+      inactive_org = create(:organization, active: false)
+
+      assert_includes Organization.active, active_org
+      refute_includes Organization.active, inactive_org
+    end
+  end
 end


### PR DESCRIPTION
# 🔗 Issue
Adds active column to Org that is default to true. 
Also cleans up the static controller a bit. 
I also made the org top nav white because A) it's cleaner and B) logos are much easier to make look good on a white background.

<img width="224" height="95" alt="image" src="https://github.com/user-attachments/assets/db7bd3ae-4e69-44cf-ab73-f9d23916acbe" />

@jmilljr24 if you have time could you set Baja and Petey to `active: false` in production please? Feel free to merge this if you are happy with it.

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->
