### PR TITLE
refac: replace date_select with date_field and reorder application_paused checkbox

### DIFF
--- a/app/views/organizations/staff/pets/_form.html.erb
+++ b/app/views/organizations/staff/pets/_form.html.erb
@@ -11,11 +11,7 @@
 
       <div class='form-group d-flex'>
         <div class='me-3'>
-          <span class=''>
-            <%= form.date_select :birth_date,
-                                 start_year: Date.today.year - 20,
-                                 end_year: Date.today.year %>
-          </span>
+          <%= form.date_field :birth_date, required: true, class: 'form-control' %>
         </div>
 
         <% pet.errors.full_messages_for(:birth_date).each do |message| %>
@@ -80,16 +76,16 @@
       </div>
 
       <div class='form-group'>
-        <div class="form-check form-switch d-flex align-items-center ps-3">
-          <%= form.hidden_field :application_paused, value: false %>
-          <%= form.check_box :application_paused, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
-          <%= render partial: "organizations/shared/tooltip", locals: { text: "Pet is visible to public but adopters cannot make applications" } %>
-        </div>
-
         <div class="form-check form-switch ps-3">
           <%= form.hidden_field :published, value: false %>
           <%= form.check_box :published, { class: "form-check-input", role: "switch", required: false }, true, false %>
           <%= render partial: "organizations/shared/tooltip", locals: { text: "Pet is visible to public" } %>
+        </div>
+
+        <div class="form-check form-switch d-flex align-items-center ps-3">
+          <%= form.hidden_field :application_paused, value: false %>
+          <%= form.check_box :application_paused, { class: "form-check-input", role: "switch", id: "flexSwitchCheckChecked" }, true, false %>
+          <%= render partial: "organizations/shared/tooltip", locals: { text: "Pet is visible to public but adopters cannot make applications" } %>
         </div>
       </div>
 


### PR DESCRIPTION
# 🔗 Issue
https://github.com/rubyforgood/homeward-tails/issues/1480

# ✍️ Description
* Changes from date_select to date_field in order to improve both resposivity and UX (by using a single field instead of a select date group)
* Change the order of the two toggles at the bottom of the form so published is first

# 📷 Screenshots/Demos
<img width="872" height="892" alt="image" src="https://github.com/user-attachments/assets/37f2f525-5a11-4b0f-bc5c-c301d744d03f" />

https://github.com/user-attachments/assets/f79ebe67-c08c-4e17-b451-5b07bf432843

