### PR TITLE
1482 change pet images size validations

### DIFF
--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -57,7 +57,7 @@ class Pet < ApplicationRecord
   # active storage validations gem
   validates :images, content_type: {in: ["image/png", "image/jpeg"]},
     limit: {max: 5},
-    size: {between: 10.kilobyte..1.megabytes}
+    size: {less_than_or_equal_to: 2.megabytes}
 
   validates :files, content_type: {in: ["image/png", "image/jpeg", "application/pdf"]},
     limit: {max: 15, message: "- 15 maximum"},

--- a/app/views/organizations/staff/shared/_attachment_form.html.erb
+++ b/app/views/organizations/staff/shared/_attachment_form.html.erb
@@ -20,7 +20,7 @@
             <% if attachment_type == 'files' %>
               Files must be .pdf, .png, or .jpeg under 2MB.
             <% elsif attachment_type == 'images' %>
-              Images must be .jpg or .png under 1MB.
+              Images must be .jpg or .png under 2MB.
             <% elsif attachment_type == 'csv' %>
               File must be a .csv under 2MB.
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -321,7 +321,7 @@ en:
             images:
               content_type_invalid: "Image must be PNG or JPEG"
               limit_out_of_range: "5 maximum"
-              file_size_out_of_range: "Image size must be between 10kb and 1Mb"
+              file_size_out_of_range: "Image size must not be larger than 2MB"
         task:
           attributes:
             pet:


### PR DESCRIPTION
# 🔗 Issue
Resolves #1482 

# ✍️ Description
This changes the size validations for pet images, removing the lower file size limit (10 kb) and increasing the upper limit to 2MB. It also updates related messages accordingly.

# 📷 Screenshots/Demos
<img width="1899" height="819" alt="Screenshot 2025-07-21 at 12 41 41" src="https://github.com/user-attachments/assets/8a066a09-7832-4e20-9e8a-4b81038852f9" />