### PR TITLE
1531 - adding background image to header on pet show page

### DIFF
--- a/app/views/layouts/adopter_foster_dashboard.html.erb
+++ b/app/views/layouts/adopter_foster_dashboard.html.erb
@@ -10,7 +10,7 @@
         <div class="container-fluid">
           <div class="row align-items-center">
             <!-- User info -->
-            <div class="col-xl-12 col-lg-12 col-md-12 col-12">
+            <div class="col-xl-12 col-lg-12 col-md-12 col-12 pt-3">
               <!-- Bg -->
               <div
                 class="rounded-top"

--- a/app/views/organizations/adoptable_pets/show.html.erb
+++ b/app/views/organizations/adoptable_pets/show.html.erb
@@ -1,8 +1,10 @@
-<header class="pt-5 pb-5">
+<header class="container-fluid pb-5">
   <div class="row align-items-center">
     <!-- Pet Info -->
-    <div class="col-xl-12 col-lg-12 col-md-12 col-12">
-      <div class="pt-16 rounded-top-md bg-gray-200"></div>
+    <div class="col-xl-12 col-lg-12 col-md-12 col-12 pt-3">
+      <!-- Bg -->
+      <div class="rounded-top-md bg-gray-200" style="background: url('<%= asset_path('background/profile-bg.jpg') %>') no-repeat; background-size: cover; height: 100px;"
+      ></div>
       <div
         class="
           d-flex align-items-center justify-content-between bg-white px-4 pt-2 pb-4


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->
https://github.com/rubyforgood/homeward-tails/issues/1531

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
Added background image to the pet show page header to match the adopter dashboard header as well as added the recommended padding-top to the header

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

<img width="1792" height="1120" alt="Screenshot 2025-08-04 at 9 52 22 AM" src="https://github.com/user-attachments/assets/6bfdbbc4-4b6d-4601-8eac-3f9d81bed9c6" />
<img width="1792" height="1120" alt="Screenshot 2025-08-04 at 9 52 25 AM" src="https://github.com/user-attachments/assets/442bf39e-0cc2-42e1-9ce1-2f8a51e3754e" />
<img width="1792" height="1120" alt="Screenshot 2025-08-04 at 9 52 34 AM" src="https://github.com/user-attachments/assets/32611356-6d87-4da0-9fd3-dc6d8436e81a" />
<img width="1792" height="1120" alt="Screenshot 2025-08-04 at 9 52 40 AM" src="https://github.com/user-attachments/assets/58798af6-3dda-4a09-9be3-76b551098692" />


