### PR TITLE
Upgrade view_component gem to latest version 4.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem "rails-controller-testing"
 gem "action_policy", "~> 0.7.4"
 
 # Use ViewComponent for our presenter pattern framework
-gem "view_component", "~> 3.22"
+gem "view_component", "~> 4.0"
 
 # Use dry-types for defining types
 gem "dry-types", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem "rails-controller-testing"
 gem "action_policy", "~> 0.7.4"
 
 # Use ViewComponent for our presenter pattern framework
-gem "view_component", "~> 4.0"
+gem "view_component", "~> 4.0.0"
 
 # Use dry-types for defining types
 gem "dry-types", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -613,10 +613,9 @@ GEM
     uri (1.0.3)
     useragent (0.16.11)
     version_gem (1.1.8)
-    view_component (3.23.2)
-      activesupport (>= 5.2.0, < 8.1)
+    view_component (4.0.0)
+      activesupport (>= 7.1.0, < 8.1)
       concurrent-ruby (~> 1)
-      method_source (~> 1.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -703,7 +702,7 @@ DEPENDENCIES
   traceroute
   turbo-rails
   tzinfo-data
-  view_component (~> 3.22)
+  view_component (~> 4.0)
   web-console
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,7 +702,7 @@ DEPENDENCIES
   traceroute
   turbo-rails
   tzinfo-data
-  view_component (~> 4.0)
+  view_component (~> 4.0.0)
   web-console
 
 RUBY VERSION

--- a/app/components/dashboard_page_component.html.erb
+++ b/app/components/dashboard_page_component.html.erb
@@ -11,7 +11,7 @@
               <%= header_subtitle %>
             </p>
           <% end %>
-          <%= breadcrumbs class: "breadcrumb", style: :ol,
+          <%= helpers.breadcrumbs class: "breadcrumb", style: :ol,
             fragment_class: "breadcrumb-item"
           %>
         </div>

--- a/app/components/dashboard_page_component.rb
+++ b/app/components/dashboard_page_component.rb
@@ -17,6 +17,6 @@ class DashboardPageComponent < ViewComponent::Base
   private
 
   def before_render
-    breadcrumb crumb, *crumb_options if crumb
+    helpers.breadcrumb crumb, *crumb_options if crumb
   end
 end

--- a/app/components/nav_tab_component.html.erb
+++ b/app/components/nav_tab_component.html.erb
@@ -1,5 +1,5 @@
 <li class="nav-item ms-0">
-  <%= active_link_to url, class: "nav-link", active: :exact do %>
+  <%= helpers.active_link_to url, class: "nav-link", active: :exact do %>
     <%= text %>
   <% end %>
 </li>

--- a/test/components/dashboard_page_component_test.rb
+++ b/test/components/dashboard_page_component_test.rb
@@ -54,8 +54,10 @@ class DashboardPageComponentTest < ViewComponent::TestCase
       end
 
       should "call breadcrumb with crumb" do
-        @component.expects(:breadcrumb).with(@crumb)
-
+        view_context = mock('view_context')
+        view_context.expects(:breadcrumb).with(@crumb)
+        view_context.stubs(:breadcrumbs).returns('')
+        ViewComponent::Base.any_instance.stubs(:helpers).returns(view_context)
         render_inline(@component)
       end
     end
@@ -68,16 +70,24 @@ class DashboardPageComponentTest < ViewComponent::TestCase
       end
 
       should "call breadcrumb with crumb and options" do
-        @component.expects(:breadcrumb).with(@crumb, *@options)
-
+        view_context = mock('view_context')
+        view_context.expects(:breadcrumb).with(@crumb, *@options)
+        view_context.stubs(:breadcrumbs).returns('')
+        ViewComponent::Base.any_instance.stubs(:helpers).returns(view_context)
         render_inline(@component)
       end
     end
 
     context "when no crumb is passed" do
-      should "not call breadcrumb" do
-        @component.expects(:breadcrumb).never
+      setup do
+        @component = DashboardPageComponent.new
+      end
 
+      should "not call breadcrumb" do
+        view_context = mock('view_context')
+        view_context.expects(:breadcrumb).never
+        view_context.stubs(:breadcrumbs).returns('')
+        ViewComponent::Base.any_instance.stubs(:helpers).returns(view_context)
         render_inline(@component)
       end
     end

--- a/test/components/dashboard_page_component_test.rb
+++ b/test/components/dashboard_page_component_test.rb
@@ -54,9 +54,9 @@ class DashboardPageComponentTest < ViewComponent::TestCase
       end
 
       should "call breadcrumb with crumb" do
-        view_context = mock('view_context')
+        view_context = mock("view_context")
         view_context.expects(:breadcrumb).with(@crumb)
-        view_context.stubs(:breadcrumbs).returns('')
+        view_context.stubs(:breadcrumbs).returns("")
         ViewComponent::Base.any_instance.stubs(:helpers).returns(view_context)
         render_inline(@component)
       end
@@ -70,9 +70,9 @@ class DashboardPageComponentTest < ViewComponent::TestCase
       end
 
       should "call breadcrumb with crumb and options" do
-        view_context = mock('view_context')
+        view_context = mock("view_context")
         view_context.expects(:breadcrumb).with(@crumb, *@options)
-        view_context.stubs(:breadcrumbs).returns('')
+        view_context.stubs(:breadcrumbs).returns("")
         ViewComponent::Base.any_instance.stubs(:helpers).returns(view_context)
         render_inline(@component)
       end
@@ -84,9 +84,9 @@ class DashboardPageComponentTest < ViewComponent::TestCase
       end
 
       should "not call breadcrumb" do
-        view_context = mock('view_context')
+        view_context = mock("view_context")
         view_context.expects(:breadcrumb).never
-        view_context.stubs(:breadcrumbs).returns('')
+        view_context.stubs(:breadcrumbs).returns("")
         ViewComponent::Base.any_instance.stubs(:helpers).returns(view_context)
         render_inline(@component)
       end


### PR DESCRIPTION
# 🔗 Issue
#1532 

# ✍️ Description
- Upgraded view_component gem to its latest version 4.0.0
- Need to do some code changes as latest version does not call helpers directly on component instance so we need to explicitly specify it in code.

# 📷 Screenshots/Demos
NA
