### PR TITLE
Memoize permissions

### DIFF
--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -85,16 +85,12 @@ module Authorizable
   # Current.organization are returned. If Acts_as_tenant.current_tenant is
   # not set and Current.organization is present an error will be raised
   # via the Acts_as_tenant initializer.
-  def active_group_names
-    person_groups
+  def permissions
+    @permissions ||= person_groups
       .where(deactivated_at: nil)
       .includes(:group)
-      .map { |pg| pg.group.name }
-  end
-
-  def permissions
-    active_group_names.flat_map do |role_name|
-      PERMISSIONS[role_name.to_sym] || []
-    end.uniq
+      .map { |pg| pg.group.name.to_sym }
+      .flat_map { |group_name| PERMISSIONS[group_name] || [] }
+      .uniq
   end
 end


### PR DESCRIPTION
# 🔗 Issue
<!-- Add link to the issue -->

# ✍️ Description
<!-- Please include a summary of the change and which issue is fixed.  -->
When a page is loaded, a persons permissions are checked for many elements on the page such as links. This causes a query for each permission to be checked. This change memoizes the permissions so we prevent multiple queries in a single request.

# 📷 Screenshots/Demos
<!-- Optional... but greatly appreciated! Please add a snapshot or quick video demonstrating the changes made in the PR. [jam.dev](jam.dev) is a great tool to help provide these in video or snapshot -->

**Before**
<img width="2808" height="1652" alt="Screenshot from 2025-08-14 05-45-50" src="https://github.com/user-attachments/assets/5b22b673-2709-46df-936f-7f09fe40d2cb" />

**After**
<img width="2808" height="1652" alt="Screenshot from 2025-08-14 05-45-08" src="https://github.com/user-attachments/assets/12778d7f-bbe7-479d-9a97-19d162b244b5" />
